### PR TITLE
Fix: smtc progress drag seek

### DIFF
--- a/src/core/smtc.rs
+++ b/src/core/smtc.rs
@@ -296,6 +296,8 @@ fn smtc_poll_loop(
                 let mut info = info_tx.borrow().clone();
                 info.position_ms = seek_pos;
                 info.last_update = Instant::now();
+                // Do not update last_smtc_pos here: SMTC timeline can lag after seek, and treating
+                // seek_pos as authoritative would make the next poll think SMTC changed and sync back.
                 let _ = info_tx.send(info);
             }
         }

--- a/src/core/smtc.rs
+++ b/src/core/smtc.rs
@@ -274,15 +274,18 @@ fn smtc_poll_loop(
             current_allowed_apps = apps;
         }
 
-        // Handle seek request
-        if let Ok(Some(seek_pos)) = seek_rx.try_recv().map(|v| Some(v)) {
+        // Handle seek request (keep only the latest)
+        let mut seek_pos = None;
+        while let Ok(v) = seek_rx.try_recv() {
+            seek_pos = Some(v);
+        }
+        if let Some(seek_pos) = seek_pos {
             if let Some(session) = get_target_session(&current_manager, &current_allowed_apps) {
                 let ticks = seek_pos as i64 * 10_000;
                 let _ = session.TryChangePlaybackPositionAsync(ticks);
                 let mut info = info_tx.borrow().clone();
                 info.position_ms = seek_pos;
                 info.last_update = Instant::now();
-                info.last_smtc_pos = seek_pos;
                 let _ = info_tx.send(info);
             }
         }

--- a/src/core/smtc.rs
+++ b/src/core/smtc.rs
@@ -49,6 +49,16 @@ impl Default for MediaInfo {
 }
 
 impl MediaInfo {
+    pub fn effective_duration_ms(&self) -> u64 {
+        if self.duration_ms > 0 {
+            self.duration_ms
+        } else if self.duration_secs > 0 {
+            self.duration_secs * 1000
+        } else {
+            0
+        }
+    }
+
     pub fn current_lyric(&self, delay_ms: i64) -> Option<String> {
         let lyrics = self.lyrics.as_ref()?;
         if lyrics.is_empty() {

--- a/src/ui/expanded/main_view.rs
+++ b/src/ui/expanded/main_view.rs
@@ -26,6 +26,7 @@ thread_local! {
     static COVER_FLIP_ANIM: RefCell<Option<std::time::Instant>> = RefCell::new(None);
     static COVER_FLIP_OLD_IMG: RefCell<Option<Image>> = RefCell::new(None);
     static PROGRESS_HOVER: RefCell<(bool, f32)> = RefCell::new((false, 0.0));
+    static PROGRESS_DRAGGING: RefCell<bool> = RefCell::new(false);
 }
 
 pub fn trigger_pause_click(current_is_playing: bool) {
@@ -69,6 +70,12 @@ pub fn trigger_cover_flip() {
 pub fn set_progress_hover(active: bool) {
     PROGRESS_HOVER.with(|cell| {
         cell.borrow_mut().0 = active;
+    });
+}
+
+pub fn set_progress_dragging(active: bool) {
+    PROGRESS_DRAGGING.with(|cell| {
+        *cell.borrow_mut() = active;
     });
 }
 
@@ -437,11 +444,16 @@ pub fn draw_main_page(
 
         let progress = PROGRESS_SMOOTH.with(|cell| {
             let mut smooth = cell.borrow_mut();
-            let diff = (raw_progress - *smooth).abs();
-            if diff > 0.3 {
+            let dragging = PROGRESS_DRAGGING.with(|d| *d.borrow());
+            if dragging {
                 *smooth = raw_progress;
             } else {
-                *smooth += (raw_progress - *smooth) * 0.15;
+                let diff = (raw_progress - *smooth).abs();
+                if diff > 0.3 {
+                    *smooth = raw_progress;
+                } else {
+                    *smooth += (raw_progress - *smooth) * 0.15;
+                }
             }
             *smooth
         });

--- a/src/ui/expanded/main_view.rs
+++ b/src/ui/expanded/main_view.rs
@@ -424,13 +424,7 @@ pub fn draw_main_page(
         } else {
             media.position_ms
         };
-        let duration_ms = if media.duration_ms > 0 {
-            media.duration_ms
-        } else if media.duration_secs > 0 {
-            media.duration_secs * 1000
-        } else {
-            0
-        };
+        let duration_ms = media.effective_duration_ms();
         let current_pos_ms = if duration_ms > 0 {
             current_pos_ms.min(duration_ms)
         } else {

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -5,8 +5,8 @@ use crate::core::render::draw_island;
 use crate::core::smtc::SmtcListener;
 use crate::ui::expanded::main_view::{
     get_next_btn_rect, get_pause_btn_rect, get_prev_btn_rect, get_progress_bar_rect,
-    set_progress_hover, trigger_cover_flip, trigger_next_click, trigger_pause_click,
-    trigger_prev_click,
+    set_progress_dragging, set_progress_hover, trigger_cover_flip, trigger_next_click,
+    trigger_pause_click, trigger_prev_click,
 };
 use crate::utils::blur::calculate_blur_sigmas;
 use crate::utils::color::get_island_border_weights;
@@ -75,6 +75,7 @@ pub struct App {
     seeking_bar_left: f32,
     seeking_bar_right: f32,
     seeking_duration_ms: u64,
+    seeking_preview_ms: u64,
 }
 
 impl Default for App {
@@ -128,6 +129,7 @@ impl Default for App {
             seeking_bar_left: 0.0,
             seeking_bar_right: 0.0,
             seeking_duration_ms: 0,
+            seeking_preview_ms: 0,
         }
     }
 }
@@ -398,15 +400,18 @@ impl ApplicationHandler for App {
                                         {
                                             let ratio = ((cx - bar_left) / (bar_right - bar_left))
                                                 .clamp(0.0, 1.0);
-                                            let seek_ms = (ratio as f64
-                                                * media.duration_secs as f64
-                                                * 1000.0)
-                                                as u64;
-                                            self.smtc.request_seek(seek_ms);
+                                            let duration_ms = if media.duration_ms > 0 {
+                                                media.duration_ms
+                                            } else {
+                                                media.duration_secs * 1000
+                                            };
+                                            let seek_ms =
+                                                (ratio as f64 * duration_ms as f64) as u64;
                                             self.seeking_progress = true;
                                             self.seeking_bar_left = bar_left;
                                             self.seeking_bar_right = bar_right;
-                                            self.seeking_duration_ms = media.duration_secs * 1000;
+                                            self.seeking_duration_ms = duration_ms;
+                                            self.seeking_preview_ms = seek_ms;
                                             return;
                                         }
                                     }
@@ -462,6 +467,9 @@ impl ApplicationHandler for App {
                         } else if state == ElementState::Released {
                             if self.seeking_progress {
                                 self.seeking_progress = false;
+                                if self.seeking_duration_ms > 0 {
+                                    self.smtc.request_seek(self.seeking_preview_ms);
+                                }
                                 return;
                             }
                             if self.is_dragging {
@@ -512,6 +520,10 @@ impl ApplicationHandler for App {
                             } else {
                                 crate::core::smtc::MediaInfo::default()
                             };
+                            if self.seeking_progress && self.seeking_duration_ms > 0 {
+                                media_info.position_ms = self.seeking_preview_ms;
+                                media_info.last_update = Instant::now();
+                            }
                             media_info.spectrum = self.audio.get_spectrum();
                             let mut music_active = false;
                             if self.config.smtc_enabled && !media_info.title.is_empty() {
@@ -743,15 +755,20 @@ impl ApplicationHandler for App {
 
             // Handle dragging on the progress bar while mouse is held
             if self.seeking_progress && is_left_button_pressed() {
-                let click_x = rel_x as f32;
+                let page_shift = self.spring_view.value * self.spring_w.value;
+                let click_x = rel_x as f32 - page_shift;
                 let ratio = ((click_x - self.seeking_bar_left)
                     / (self.seeking_bar_right - self.seeking_bar_left))
                     .clamp(0.0, 1.0);
                 let seek_ms = (ratio as f64 * self.seeking_duration_ms as f64) as u64;
-                self.smtc.request_seek(seek_ms);
+                self.seeking_preview_ms = seek_ms;
                 window.request_redraw();
             } else if self.seeking_progress {
                 self.seeking_progress = false;
+                if self.seeking_duration_ms > 0 {
+                    self.smtc.request_seek(self.seeking_preview_ms);
+                    window.request_redraw();
+                }
             }
 
             let progress_hover_active = if self.seeking_progress {
@@ -780,6 +797,7 @@ impl ApplicationHandler for App {
                 false
             };
             set_progress_hover(progress_hover_active);
+            set_progress_dragging(self.seeking_progress);
 
             if self.is_dragging {
                 let diff_y = self.drag_start_py - py;

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -760,6 +760,7 @@ impl ApplicationHandler for App {
                 self.seeking_preview_ms = seek_ms;
                 window.request_redraw();
             } else if self.seeking_progress {
+                // Fallback: handle cases where mouse release isn't observed (e.g. released outside window)
                 self.seeking_progress = false;
                 if self.seeking_duration_ms > 0 {
                     self.smtc.request_seek(self.seeking_preview_ms);

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -206,7 +206,7 @@ impl ApplicationHandler for App {
                             style & !(WS_MAXIMIZEBOX.0 as isize | WS_THICKFRAME.0 as isize),
                         );
                     }
-                    set_glass_hwnd(win32_handle.hwnd.get() as isize);
+                    set_glass_hwnd(win32_handle.hwnd.get());
                 }
             }
 

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -400,11 +400,7 @@ impl ApplicationHandler for App {
                                         {
                                             let ratio = ((cx - bar_left) / (bar_right - bar_left))
                                                 .clamp(0.0, 1.0);
-                                            let duration_ms = if media.duration_ms > 0 {
-                                                media.duration_ms
-                                            } else {
-                                                media.duration_secs * 1000
-                                            };
+                                            let duration_ms = media.effective_duration_ms();
                                             let seek_ms =
                                                 (ratio as f64 * duration_ms as f64) as u64;
                                             self.seeking_progress = true;


### PR DESCRIPTION
## 问题
在播放 B 站等浏览器媒体时，进度条拖动体验异常：

- 拖动时进度不跟手（位置和鼠标对不上）
- 动画不流畅，松手后看起来会跳转多次、卡顿后才继续播放
## 原因分析
- 拖动时的坐标计算未扣除页面切换的 page_shift ，导致拖动位置偏移
- 拖动期间每帧都发送 seek 请求，后台消费频率较低，seek 堆积后会“补执行”历史请求，造成多次跳转/卡顿
- seek 后短时间内 SMTC 时间线更新滞后，会出现本地位置被旧值回拉的抖动体感
## 修复方案
- UI：拖动期间只更新本地预览位置，松手时只提交一次 seek；拖动坐标扣除 page_shift ，保证跟手
- UI：拖动时禁用进度平滑插值，避免滑块永远滞后于鼠标
- SMTC：合并 seek 请求（drain 队列只执行最新一次），避免堆积导致多次跳转
- 小优化：在 MediaInfo 增加 effective_duration_ms() ，统一 duration 的 fallback 逻辑
- 维护性：补充 seek fallback 路径注释（处理松手发生在窗口外等边界情况）