### PR TITLE
Fix: settings scroll fps

### DIFF
--- a/src/utils/anim.rs
+++ b/src/utils/anim.rs
@@ -7,7 +7,7 @@ struct AnimValue {
 }
 
 pub struct AnimPool {
-    values: HashMap<String, AnimValue>,
+    values: HashMap<u64, AnimValue>,
     default_speed: f32,
 }
 
@@ -19,18 +19,18 @@ impl AnimPool {
         }
     }
 
-    pub fn set(&mut self, key: &str, target: f32) {
+    pub fn set(&mut self, key: u64, target: f32) {
         let speed = self.default_speed;
         self.set_with_speed(key, target, speed);
     }
 
-    pub fn set_with_speed(&mut self, key: &str, target: f32, speed: f32) {
-        if let Some(v) = self.values.get_mut(key) {
+    pub fn set_with_speed(&mut self, key: u64, target: f32, speed: f32) {
+        if let Some(v) = self.values.get_mut(&key) {
             v.target = target;
             v.speed = speed;
         } else {
             self.values.insert(
-                key.to_string(),
+                key,
                 AnimValue {
                     value: 0.0,
                     target,
@@ -40,8 +40,8 @@ impl AnimPool {
         }
     }
 
-    pub fn get(&self, key: &str) -> f32 {
-        self.values.get(key).map(|v| v.value).unwrap_or(0.0)
+    pub fn get(&self, key: u64) -> f32 {
+        self.values.get(&key).map(|v| v.value).unwrap_or(0.0)
     }
 
     pub fn tick(&mut self) -> bool {

--- a/src/utils/font.rs
+++ b/src/utils/font.rs
@@ -133,21 +133,6 @@ impl FontManager {
         canvas.draw_str(text, pos, &font, paint);
     }
 
-    pub fn draw_text_centered(
-        &self,
-        canvas: &Canvas,
-        text: &str,
-        center_x: f32,
-        y: f32,
-        size: f32,
-        bold: bool,
-        paint: &Paint,
-    ) {
-        let font = self.get_font(size, bold);
-        let (_, rect) = font.measure_str(text, None);
-        canvas.draw_str(text, (center_x - rect.width() / 2.0, y), &font, paint);
-    }
-
     pub fn draw_text_in_rect(
         &self,
         canvas: &Canvas,

--- a/src/utils/font.rs
+++ b/src/utils/font.rs
@@ -167,7 +167,7 @@ impl FontManager {
     }
 
     pub fn measure_text_cached(&self, text: &str, size: f32, style: FontStyle) -> f32 {
-        let cache_key = format!("measure-{}-{:?}-{}", text, style, size as i32);
+        let cache_key = format!("measure\0{}\0{:?}\0{}", text, style, size as i32);
         TEXT_CACHE.with(|cache| {
             let mut cache_mut = cache.borrow_mut();
             if cache_mut.len() > 500 {
@@ -223,7 +223,7 @@ impl FontManager {
         align_center: bool,
         max_w: f32,
     ) {
-        let cache_key = format!("{}-{}-{:?}-{}", text, max_w as i32, style, size as i32);
+        let cache_key = format!("{}\0{}\0{:?}\0{}", text, max_w as i32, style, size as i32);
         TEXT_CACHE.with(|cache| {
             let mut cache_mut = cache.borrow_mut();
             if cache_mut.len() > 500 {

--- a/src/utils/settings_ui/mod.rs
+++ b/src/utils/settings_ui/mod.rs
@@ -3,6 +3,8 @@ pub mod input;
 pub mod items;
 pub mod renderer;
 
+pub const HOVER_ROW_KEY_BASE: u64 = 10_000;
+
 pub use anim::SwitchAnimator;
 pub use input::{ClickResult, hit_test, hover_test};
 pub use renderer::{content_height, draw_items};

--- a/src/utils/settings_ui/renderer.rs
+++ b/src/utils/settings_ui/renderer.rs
@@ -1,11 +1,10 @@
 use super::anim::SwitchAnimator;
 use super::items::*;
+use super::HOVER_ROW_KEY_BASE;
 use crate::utils::anim::AnimPool;
 use crate::utils::color::*;
 use crate::utils::font::FontManager;
 use skia_safe::{Canvas, Color, FontStyle, Paint, Rect};
-
-const HOVER_ROW_KEY_BASE: u64 = 10_000;
 
 fn draw_switch(canvas: &Canvas, x: f32, y: f32, pos: f32, enabled: bool) {
     let mut paint = Paint::default();

--- a/src/utils/settings_ui/renderer.rs
+++ b/src/utils/settings_ui/renderer.rs
@@ -3,7 +3,9 @@ use super::items::*;
 use crate::utils::anim::AnimPool;
 use crate::utils::color::*;
 use crate::utils::font::FontManager;
-use skia_safe::{Canvas, Color, Paint, Rect};
+use skia_safe::{Canvas, Color, FontStyle, Paint, Rect};
+
+const HOVER_ROW_KEY_BASE: u64 = 10_000;
 
 fn draw_switch(canvas: &Canvas, x: f32, y: f32, pos: f32, enabled: bool) {
     let mut paint = Paint::default();
@@ -97,27 +99,6 @@ fn draw_pill_btn(
     fm.draw_text_in_rect(canvas, label, x, y + 17.0, w, 12.0, true, &paint);
 }
 
-fn truncate_text(fm: &FontManager, text: &str, size: f32, max_w: f32) -> String {
-    let (w, _) = fm.measure(text, size, false);
-    if w <= max_w {
-        return text.to_string();
-    }
-    let ellipsis = "...";
-    let (ew, _) = fm.measure(ellipsis, size, false);
-    let mut result = String::new();
-    let mut current_w = 0.0;
-    for c in text.chars() {
-        let (cw, _) = fm.measure(&c.to_string(), size, false);
-        if current_w + cw + ew > max_w {
-            result.push_str(ellipsis);
-            return result;
-        }
-        current_w += cw;
-        result.push(c);
-    }
-    result
-}
-
 fn count_group_rows(items: &[SettingsItem], start: usize) -> usize {
     let mut count = 0;
     let mut i = start;
@@ -141,8 +122,7 @@ fn draw_row_hover(
     in_group: bool,
     hover_anims: &AnimPool,
 ) {
-    let key = format!("hover_row_{}", row_idx);
-    let val = hover_anims.get(&key);
+    let val = hover_anims.get(HOVER_ROW_KEY_BASE + row_idx as u64);
     if val > 0.005 {
         let alpha = (val * 15.0) as u8;
         let mut hp = Paint::default();
@@ -173,6 +153,8 @@ pub fn draw_items(
     width: f32,
     anims: &SwitchAnimator,
     hover_anims: &AnimPool,
+    visible_min_y: f32,
+    visible_max_y: f32,
 ) {
     let fm = FontManager::global();
     let mut y = start_y;
@@ -188,43 +170,58 @@ pub fn draw_items(
     let mut i = 0;
     while i < items.len() {
         let item = &items[i];
+        if y > visible_max_y + 120.0 {
+            break;
+        }
         match item {
             SettingsItem::PageTitle { text } => {
-                paint.set_color(COLOR_TEXT_PRI);
-                fm.draw_text(
-                    canvas,
-                    text,
-                    (CONTENT_PADDING, y + 35.0),
-                    20.0,
-                    true,
-                    &paint,
-                );
+                let h = item.height();
+                if y + h >= visible_min_y && y <= visible_max_y {
+                    paint.set_color(COLOR_TEXT_PRI);
+                    fm.draw_text_cached(
+                        canvas,
+                        text,
+                        (CONTENT_PADDING, y + 35.0),
+                        20.0,
+                        FontStyle::bold(),
+                        &paint,
+                        false,
+                        f32::MAX,
+                    );
+                }
             }
             SettingsItem::SectionHeader { label } => {
-                paint.set_color(COLOR_TEXT_SEC);
-                fm.draw_text(
-                    canvas,
-                    label,
-                    (CONTENT_PADDING + 4.0, y + 22.0),
-                    12.0,
-                    false,
-                    &paint,
-                );
+                let h = item.height();
+                if y + h >= visible_min_y && y <= visible_max_y {
+                    paint.set_color(COLOR_TEXT_SEC);
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (CONTENT_PADDING + 4.0, y + 22.0),
+                        12.0,
+                        FontStyle::normal(),
+                        &paint,
+                        false,
+                        f32::MAX,
+                    );
+                }
             }
             SettingsItem::GroupStart => {
                 in_group = true;
                 group_current_row = 0;
                 group_row_count = count_group_rows(items, i + 1);
                 let total_h = group_row_count as f32 * ROW_HEIGHT;
-                let mut bg = Paint::default();
-                bg.set_anti_alias(true);
-                bg.set_color(COLOR_GROUP_BG);
-                canvas.draw_round_rect(
-                    Rect::from_xywh(CONTENT_PADDING, y, content_w, total_h),
-                    GROUP_RADIUS,
-                    GROUP_RADIUS,
-                    &bg,
-                );
+                if y + total_h >= visible_min_y && y <= visible_max_y {
+                    let mut bg = Paint::default();
+                    bg.set_anti_alias(true);
+                    bg.set_color(COLOR_GROUP_BG);
+                    canvas.draw_round_rect(
+                        Rect::from_xywh(CONTENT_PADDING, y, content_w, total_h),
+                        GROUP_RADIUS,
+                        GROUP_RADIUS,
+                        &bg,
+                    );
+                }
             }
             SettingsItem::GroupEnd => {
                 in_group = false;
@@ -234,47 +231,75 @@ pub fn draw_items(
                 value,
                 enabled,
             } => {
-                draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                    draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                }
                 let row_x = CONTENT_PADDING + GROUP_INNER_PAD;
                 let cy = y + ROW_HEIGHT / 2.0;
 
-                paint.set_color(if *enabled {
-                    COLOR_TEXT_PRI
-                } else {
-                    COLOR_TEXT_SEC
-                });
-                fm.draw_text(canvas, label, (row_x, cy + 5.0), 13.0, false, &paint);
+                if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                    paint.set_color(if *enabled {
+                        COLOR_TEXT_PRI
+                    } else {
+                        COLOR_TEXT_SEC
+                    });
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (row_x, cy + 5.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        false,
+                        f32::MAX,
+                    );
+                }
 
                 let btn_inc_x = CONTENT_PADDING + content_w - GROUP_INNER_PAD - STEPPER_BTN_SIZE;
                 let btn_dec_x = btn_inc_x - STEPPER_BTN_SIZE - 60.0;
                 let btn_y = cy - STEPPER_BTN_SIZE / 2.0;
-                draw_stepper_btn(canvas, btn_dec_x, btn_y, "-", *enabled);
-                draw_stepper_btn(canvas, btn_inc_x, btn_y, "+", *enabled);
+                if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                    draw_stepper_btn(canvas, btn_dec_x, btn_y, "-", *enabled);
+                    draw_stepper_btn(canvas, btn_inc_x, btn_y, "+", *enabled);
+                }
 
                 let val_center = (btn_dec_x + STEPPER_BTN_SIZE + btn_inc_x) / 2.0;
-                paint.set_color(if *enabled {
-                    COLOR_TEXT_PRI
-                } else {
-                    COLOR_TEXT_SEC
-                });
-                fm.draw_text_centered(canvas, value, val_center, cy + 5.0, 13.0, false, &paint);
+                if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                    paint.set_color(if *enabled {
+                        COLOR_TEXT_PRI
+                    } else {
+                        COLOR_TEXT_SEC
+                    });
+                    fm.draw_text_cached(
+                        canvas,
+                        value,
+                        (val_center, cy + 5.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        true,
+                        f32::MAX,
+                    );
+                }
 
                 if in_group {
                     group_current_row += 1;
                     if group_current_row < group_row_count {
-                        let mut sep = Paint::default();
-                        sep.set_anti_alias(true);
-                        sep.set_color(color_separator());
-                        sep.set_stroke_width(0.5);
-                        sep.set_style(skia_safe::paint::Style::Stroke);
-                        canvas.draw_line(
-                            (row_x, y + ROW_HEIGHT),
-                            (
-                                CONTENT_PADDING + content_w - GROUP_INNER_PAD,
-                                y + ROW_HEIGHT,
-                            ),
-                            &sep,
-                        );
+                        if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                            let mut sep = Paint::default();
+                            sep.set_anti_alias(true);
+                            sep.set_color(color_separator());
+                            sep.set_stroke_width(0.5);
+                            sep.set_style(skia_safe::paint::Style::Stroke);
+                            canvas.draw_line(
+                                (row_x, y + ROW_HEIGHT),
+                                (
+                                    CONTENT_PADDING + content_w - GROUP_INNER_PAD,
+                                    y + ROW_HEIGHT,
+                                ),
+                                &sep,
+                            );
+                        }
                     }
                 }
                 row_idx += 1;
@@ -284,38 +309,55 @@ pub fn draw_items(
                 on: _,
                 enabled,
             } => {
-                draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                    draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                }
                 let row_x = CONTENT_PADDING + GROUP_INNER_PAD;
                 let cy = y + ROW_HEIGHT / 2.0;
 
-                paint.set_color(if *enabled {
-                    COLOR_TEXT_PRI
-                } else {
-                    COLOR_TEXT_SEC
-                });
-                fm.draw_text(canvas, label, (row_x, cy + 5.0), 13.0, false, &paint);
+                if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                    paint.set_color(if *enabled {
+                        COLOR_TEXT_PRI
+                    } else {
+                        COLOR_TEXT_SEC
+                    });
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (row_x, cy + 5.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        false,
+                        f32::MAX,
+                    );
+                }
 
                 let toggle_x = CONTENT_PADDING + content_w - GROUP_INNER_PAD - TOGGLE_W;
                 let toggle_y = cy - TOGGLE_H / 2.0;
-                draw_switch(canvas, toggle_x, toggle_y, anims.get(switch_idx), *enabled);
+                if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                    draw_switch(canvas, toggle_x, toggle_y, anims.get(switch_idx), *enabled);
+                }
                 switch_idx += 1;
 
                 if in_group {
                     group_current_row += 1;
                     if group_current_row < group_row_count {
-                        let mut sep = Paint::default();
-                        sep.set_anti_alias(true);
-                        sep.set_color(color_separator());
-                        sep.set_stroke_width(0.5);
-                        sep.set_style(skia_safe::paint::Style::Stroke);
-                        canvas.draw_line(
-                            (row_x, y + ROW_HEIGHT),
-                            (
-                                CONTENT_PADDING + content_w - GROUP_INNER_PAD,
-                                y + ROW_HEIGHT,
-                            ),
-                            &sep,
-                        );
+                        if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                            let mut sep = Paint::default();
+                            sep.set_anti_alias(true);
+                            sep.set_color(color_separator());
+                            sep.set_stroke_width(0.5);
+                            sep.set_style(skia_safe::paint::Style::Stroke);
+                            canvas.draw_line(
+                                (row_x, y + ROW_HEIGHT),
+                                (
+                                    CONTENT_PADDING + content_w - GROUP_INNER_PAD,
+                                    y + ROW_HEIGHT,
+                                ),
+                                &sep,
+                            );
+                        }
                     }
                 }
                 row_idx += 1;
@@ -325,57 +367,73 @@ pub fn draw_items(
                 btn_label,
                 reset_label,
             } => {
-                draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                let visible = y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y;
+                if visible {
+                    draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                }
                 let row_x = CONTENT_PADDING + GROUP_INNER_PAD;
                 let cy = y + ROW_HEIGHT / 2.0;
 
-                paint.set_color(COLOR_TEXT_PRI);
-                fm.draw_text(canvas, label, (row_x, cy + 5.0), 13.0, false, &paint);
+                if visible {
+                    paint.set_color(COLOR_TEXT_PRI);
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (row_x, cy + 5.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        false,
+                        f32::MAX,
+                    );
 
-                let sel_w: f32 = 60.0;
-                let sel_x = CONTENT_PADDING + content_w - GROUP_INNER_PAD - sel_w;
-                draw_pill_btn(
-                    canvas,
-                    sel_x,
-                    cy - 13.0,
-                    sel_w,
-                    26.0,
-                    btn_label,
-                    COLOR_TEXT_PRI,
-                    COLOR_CARD_HIGHLIGHT,
-                );
-
-                if let Some(rl) = reset_label {
-                    let rst_w: f32 = 60.0;
-                    let rst_x = sel_x - rst_w - 6.0;
+                    let sel_w: f32 = 60.0;
+                    let sel_x = CONTENT_PADDING + content_w - GROUP_INNER_PAD - sel_w;
                     draw_pill_btn(
                         canvas,
-                        rst_x,
+                        sel_x,
                         cy - 13.0,
-                        rst_w,
+                        sel_w,
                         26.0,
-                        rl,
-                        COLOR_DANGER,
+                        btn_label,
+                        COLOR_TEXT_PRI,
                         COLOR_CARD_HIGHLIGHT,
                     );
+
+                    if let Some(rl) = reset_label {
+                        let rst_w: f32 = 60.0;
+                        let rst_x = sel_x - rst_w - 6.0;
+                        draw_pill_btn(
+                            canvas,
+                            rst_x,
+                            cy - 13.0,
+                            rst_w,
+                            26.0,
+                            rl,
+                            COLOR_DANGER,
+                            COLOR_CARD_HIGHLIGHT,
+                        );
+                    }
                 }
 
                 if in_group {
                     group_current_row += 1;
                     if group_current_row < group_row_count {
-                        let mut sep = Paint::default();
-                        sep.set_anti_alias(true);
-                        sep.set_color(color_separator());
-                        sep.set_stroke_width(0.5);
-                        sep.set_style(skia_safe::paint::Style::Stroke);
-                        canvas.draw_line(
-                            (row_x, y + ROW_HEIGHT),
-                            (
-                                CONTENT_PADDING + content_w - GROUP_INNER_PAD,
-                                y + ROW_HEIGHT,
-                            ),
-                            &sep,
-                        );
+                        if visible {
+                            let mut sep = Paint::default();
+                            sep.set_anti_alias(true);
+                            sep.set_color(color_separator());
+                            sep.set_stroke_width(0.5);
+                            sep.set_style(skia_safe::paint::Style::Stroke);
+                            canvas.draw_line(
+                                (row_x, y + ROW_HEIGHT),
+                                (
+                                    CONTENT_PADDING + content_w - GROUP_INNER_PAD,
+                                    y + ROW_HEIGHT,
+                                ),
+                                &sep,
+                            );
+                        }
                     }
                 }
                 row_idx += 1;
@@ -385,16 +443,30 @@ pub fn draw_items(
                 options,
                 enabled,
             } => {
-                draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                let visible = y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y;
+                if visible {
+                    draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                }
                 let row_x = CONTENT_PADDING + GROUP_INNER_PAD;
                 let cy = y + ROW_HEIGHT / 2.0;
 
-                paint.set_color(if *enabled {
-                    COLOR_TEXT_PRI
-                } else {
-                    COLOR_TEXT_SEC
-                });
-                fm.draw_text(canvas, label, (row_x, cy + 5.0), 13.0, false, &paint);
+                if visible {
+                    paint.set_color(if *enabled {
+                        COLOR_TEXT_PRI
+                    } else {
+                        COLOR_TEXT_SEC
+                    });
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (row_x, cy + 5.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        false,
+                        f32::MAX,
+                    );
+                }
 
                 let selected_label = options
                     .iter()
@@ -405,75 +477,79 @@ pub fn draw_items(
                 let btn_x = CONTENT_PADDING + content_w - GROUP_INNER_PAD - POPUP_BTN_W;
                 let btn_y = cy - POPUP_BTN_H / 2.0;
 
-                let mut p = Paint::default();
-                p.set_anti_alias(true);
-                p.set_color(if *enabled {
-                    COLOR_CARD_HIGHLIGHT
-                } else {
-                    COLOR_DISABLED
-                });
-                canvas.draw_round_rect(
-                    Rect::from_xywh(btn_x, btn_y, POPUP_BTN_W, POPUP_BTN_H),
-                    POPUP_BTN_R,
-                    POPUP_BTN_R,
-                    &p,
-                );
+                if visible {
+                    let mut p = Paint::default();
+                    p.set_anti_alias(true);
+                    p.set_color(if *enabled {
+                        COLOR_CARD_HIGHLIGHT
+                    } else {
+                        COLOR_DISABLED
+                    });
+                    canvas.draw_round_rect(
+                        Rect::from_xywh(btn_x, btn_y, POPUP_BTN_W, POPUP_BTN_H),
+                        POPUP_BTN_R,
+                        POPUP_BTN_R,
+                        &p,
+                    );
 
-                p.set_color(if *enabled {
-                    COLOR_TEXT_PRI
-                } else {
-                    COLOR_TEXT_SEC
-                });
-                let text_w = POPUP_BTN_W - 22.0;
-                fm.draw_text_in_rect(
-                    canvas,
-                    selected_label,
-                    btn_x + 4.0,
-                    btn_y + 17.0,
-                    text_w,
-                    12.0,
-                    true,
-                    &p,
-                );
+                    p.set_color(if *enabled {
+                        COLOR_TEXT_PRI
+                    } else {
+                        COLOR_TEXT_SEC
+                    });
+                    let text_w = POPUP_BTN_W - 22.0;
+                    fm.draw_text_in_rect(
+                        canvas,
+                        selected_label,
+                        btn_x + 4.0,
+                        btn_y + 17.0,
+                        text_w,
+                        12.0,
+                        true,
+                        &p,
+                    );
 
-                let chev_cx = btn_x + POPUP_BTN_W - 12.0;
-                let chev_cy = cy;
-                let chev_svg = format!(
-                    "M {} {} L {} {} L {} {}",
-                    chev_cx - 3.0,
-                    chev_cy - 1.5,
-                    chev_cx,
-                    chev_cy + 1.5,
-                    chev_cx + 3.0,
-                    chev_cy - 1.5,
-                );
-                p.set_color(if *enabled {
-                    COLOR_TEXT_SEC
-                } else {
-                    COLOR_DISABLED
-                });
-                p.set_style(skia_safe::paint::Style::Stroke);
-                p.set_stroke_width(1.5);
-                if let Some(chev_path) = skia_safe::Path::from_svg(&chev_svg) {
-                    canvas.draw_path(&chev_path, &p);
+                    let chev_cx = btn_x + POPUP_BTN_W - 12.0;
+                    let chev_cy = cy;
+                    let chev_svg = format!(
+                        "M {} {} L {} {} L {} {}",
+                        chev_cx - 3.0,
+                        chev_cy - 1.5,
+                        chev_cx,
+                        chev_cy + 1.5,
+                        chev_cx + 3.0,
+                        chev_cy - 1.5,
+                    );
+                    p.set_color(if *enabled {
+                        COLOR_TEXT_SEC
+                    } else {
+                        COLOR_DISABLED
+                    });
+                    p.set_style(skia_safe::paint::Style::Stroke);
+                    p.set_stroke_width(1.5);
+                    if let Some(chev_path) = skia_safe::Path::from_svg(&chev_svg) {
+                        canvas.draw_path(&chev_path, &p);
+                    }
                 }
 
                 if in_group {
                     group_current_row += 1;
                     if group_current_row < group_row_count {
-                        let mut sep = Paint::default();
-                        sep.set_anti_alias(true);
-                        sep.set_color(color_separator());
-                        sep.set_stroke_width(0.5);
-                        sep.set_style(skia_safe::paint::Style::Stroke);
-                        canvas.draw_line(
-                            (row_x, y + ROW_HEIGHT),
-                            (
-                                CONTENT_PADDING + content_w - GROUP_INNER_PAD,
-                                y + ROW_HEIGHT,
-                            ),
-                            &sep,
-                        );
+                        if visible {
+                            let mut sep = Paint::default();
+                            sep.set_anti_alias(true);
+                            sep.set_color(color_separator());
+                            sep.set_stroke_width(0.5);
+                            sep.set_style(skia_safe::paint::Style::Stroke);
+                            canvas.draw_line(
+                                (row_x, y + ROW_HEIGHT),
+                                (
+                                    CONTENT_PADDING + content_w - GROUP_INNER_PAD,
+                                    y + ROW_HEIGHT,
+                                ),
+                                &sep,
+                            );
+                        }
                     }
                 }
                 row_idx += 1;
@@ -483,7 +559,10 @@ pub fn draw_items(
                 active,
                 enabled,
             } => {
-                draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                let visible = y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y;
+                if visible {
+                    draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                }
                 let row_x = CONTENT_PADDING + GROUP_INNER_PAD;
                 let cy = y + ROW_HEIGHT / 2.0;
 
@@ -493,7 +572,7 @@ pub fn draw_items(
 
                 let mut p = Paint::default();
                 p.set_anti_alias(true);
-                if *active && *enabled {
+                if visible && *active && *enabled {
                     p.set_color(COLOR_ACCENT);
                     canvas.draw_round_rect(
                         Rect::from_xywh(check_x, check_y, check_size, check_size),
@@ -516,7 +595,7 @@ pub fn draw_items(
                     if let Some(path) = skia_safe::Path::from_svg(&svg) {
                         canvas.draw_path(&path, &p);
                     }
-                } else {
+                } else if visible {
                     p.set_color(if *enabled {
                         COLOR_CARD_HIGHLIGHT
                     } else {
@@ -532,69 +611,121 @@ pub fn draw_items(
                     );
                 }
 
-                paint.set_color(if *enabled {
-                    COLOR_TEXT_PRI
-                } else {
-                    COLOR_TEXT_SEC
-                });
-                let max_label_w = check_x - row_x - 8.0;
-                let display = truncate_text(fm, label, 13.0, max_label_w);
-                fm.draw_text(canvas, &display, (row_x, cy + 5.0), 13.0, false, &paint);
+                if visible {
+                    paint.set_color(if *enabled {
+                        COLOR_TEXT_PRI
+                    } else {
+                        COLOR_TEXT_SEC
+                    });
+                    let max_label_w = check_x - row_x - 8.0;
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (row_x, cy + 5.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        false,
+                        max_label_w,
+                    );
+                }
 
                 if in_group {
                     group_current_row += 1;
                     if group_current_row < group_row_count {
-                        let mut sep = Paint::default();
-                        sep.set_anti_alias(true);
-                        sep.set_color(color_separator());
-                        sep.set_stroke_width(0.5);
-                        sep.set_style(skia_safe::paint::Style::Stroke);
-                        canvas.draw_line(
-                            (row_x, y + ROW_HEIGHT),
-                            (
-                                CONTENT_PADDING + content_w - GROUP_INNER_PAD,
-                                y + ROW_HEIGHT,
-                            ),
-                            &sep,
-                        );
+                        if visible {
+                            let mut sep = Paint::default();
+                            sep.set_anti_alias(true);
+                            sep.set_color(color_separator());
+                            sep.set_stroke_width(0.5);
+                            sep.set_style(skia_safe::paint::Style::Stroke);
+                            canvas.draw_line(
+                                (row_x, y + ROW_HEIGHT),
+                                (
+                                    CONTENT_PADDING + content_w - GROUP_INNER_PAD,
+                                    y + ROW_HEIGHT,
+                                ),
+                                &sep,
+                            );
+                        }
                     }
                 }
                 row_idx += 1;
             }
             SettingsItem::RowLabel { label } => {
-                draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                let visible = y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y;
+                if visible {
+                    draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
+                }
                 let row_x = CONTENT_PADDING + GROUP_INNER_PAD;
                 let cy = y + ROW_HEIGHT / 2.0;
-                paint.set_color(COLOR_TEXT_SEC);
-                fm.draw_text(canvas, label, (row_x, cy + 5.0), 13.0, false, &paint);
+                if visible {
+                    paint.set_color(COLOR_TEXT_SEC);
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (row_x, cy + 5.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        false,
+                        f32::MAX,
+                    );
+                }
 
                 if in_group {
                     group_current_row += 1;
                     if group_current_row < group_row_count {
-                        let mut sep = Paint::default();
-                        sep.set_anti_alias(true);
-                        sep.set_color(color_separator());
-                        sep.set_stroke_width(0.5);
-                        sep.set_style(skia_safe::paint::Style::Stroke);
-                        canvas.draw_line(
-                            (row_x, y + ROW_HEIGHT),
-                            (
-                                CONTENT_PADDING + content_w - GROUP_INNER_PAD,
-                                y + ROW_HEIGHT,
-                            ),
-                            &sep,
-                        );
+                        if visible {
+                            let mut sep = Paint::default();
+                            sep.set_anti_alias(true);
+                            sep.set_color(color_separator());
+                            sep.set_stroke_width(0.5);
+                            sep.set_style(skia_safe::paint::Style::Stroke);
+                            canvas.draw_line(
+                                (row_x, y + ROW_HEIGHT),
+                                (
+                                    CONTENT_PADDING + content_w - GROUP_INNER_PAD,
+                                    y + ROW_HEIGHT,
+                                ),
+                                &sep,
+                            );
+                        }
                     }
                 }
                 row_idx += 1;
             }
             SettingsItem::CenterLink { label, color } => {
-                paint.set_color(*color);
-                fm.draw_text_centered(canvas, label, width / 2.0, y + 24.0, 13.0, false, &paint);
+                let h = item.height();
+                if y + h >= visible_min_y && y <= visible_max_y {
+                    paint.set_color(*color);
+                    fm.draw_text_cached(
+                        canvas,
+                        label,
+                        (width / 2.0, y + 24.0),
+                        13.0,
+                        FontStyle::normal(),
+                        &paint,
+                        true,
+                        f32::MAX,
+                    );
+                }
             }
             SettingsItem::CenterText { text, size, color } => {
-                paint.set_color(*color);
-                fm.draw_text_centered(canvas, text, width / 2.0, y + 22.0, *size, false, &paint);
+                let h = item.height();
+                if y + h >= visible_min_y && y <= visible_max_y {
+                    paint.set_color(*color);
+                    fm.draw_text_cached(
+                        canvas,
+                        text,
+                        (width / 2.0, y + 22.0),
+                        *size,
+                        FontStyle::normal(),
+                        &paint,
+                        true,
+                        f32::MAX,
+                    );
+                }
             }
             SettingsItem::Spacer { .. } => {}
         }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -11,7 +11,7 @@ use crate::utils::settings_ui::*;
 use skia_safe::{Color, Paint, Rect, surfaces};
 use softbuffer::{Context, Surface};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use windows::Win32::System::Threading::{MUTEX_ALL_ACCESS, OpenMutexW};
 use windows::core::w;
 use winit::application::ApplicationHandler;
@@ -26,6 +26,10 @@ const WIN_H: f32 = 480.0;
 const SIDEBAR_W: f32 = 180.0;
 const SIDEBAR_ROW_H: f32 = 32.0;
 const CONTENT_START_Y: f32 = 10.0;
+
+const POPUP_OPACITY_KEY: u64 = 1;
+const SIDEBAR_KEY_BASE: u64 = 1_000;
+const HOVER_ROW_KEY_BASE: u64 = 10_000;
 
 #[derive(Clone, PartialEq)]
 enum PopupKind {
@@ -77,7 +81,6 @@ impl PopupState {
 pub struct SettingsApp {
     window: Option<Arc<Window>>,
     surface: Option<Surface<Arc<Window>, Arc<Window>>>,
-    sk_surface: Option<skia_safe::Surface>,
     config: AppConfig,
     active_page: usize,
     switch_anim: SwitchAnimator,
@@ -86,11 +89,18 @@ pub struct SettingsApp {
     frame_count: u64,
     scroll_y: f32,
     target_scroll_y: f32,
+    scroll_vel_y: f32,
+    last_frame_time: Instant,
     detected_apps: Vec<String>,
     sidebar_hover: i32,
     popup: Option<PopupState>,
     hover_row: Option<usize>,
     total_rows: usize,
+    items_dirty: bool,
+    cached_items: Vec<SettingsItem>,
+    cached_content_height: f32,
+    cached_max_scroll: f32,
+    cached_row_tops: Vec<f32>,
 }
 
 impl SettingsApp {
@@ -109,7 +119,6 @@ impl SettingsApp {
         Self {
             window: None,
             surface: None,
-            sk_surface: None,
             config,
             active_page: 0,
             switch_anim,
@@ -118,11 +127,18 @@ impl SettingsApp {
             frame_count: 0,
             scroll_y: 0.0,
             target_scroll_y: 0.0,
+            scroll_vel_y: 0.0,
+            last_frame_time: Instant::now(),
             detected_apps: Vec::new(),
             sidebar_hover: -1,
             popup: None,
             hover_row: None,
             total_rows: 0,
+            items_dirty: true,
+            cached_items: Vec::new(),
+            cached_content_height: 0.0,
+            cached_max_scroll: 0.0,
+            cached_row_tops: Vec::new(),
         }
     }
 
@@ -409,6 +425,28 @@ impl SettingsApp {
         }
     }
 
+    fn rebuild_items_cache(&mut self) {
+        self.cached_items = self.build_current_items();
+        self.cached_content_height = content_height(&self.cached_items, CONTENT_START_Y);
+        self.cached_max_scroll = (self.cached_content_height - WIN_H).max(0.0);
+        self.cached_row_tops.clear();
+        let mut y = CONTENT_START_Y;
+        for item in &self.cached_items {
+            if item.is_row() {
+                self.cached_row_tops.push(y);
+            }
+            y += item.height();
+        }
+        self.total_rows = self.cached_row_tops.len();
+        self.items_dirty = false;
+    }
+
+    fn ensure_items_cache(&mut self) {
+        if self.items_dirty {
+            self.rebuild_items_cache();
+        }
+    }
+
     fn get_monitor_list(&self) -> Vec<String> {
         use windows::Win32::Graphics::Gdi::*;
         let mut monitors: Vec<String> = Vec::new();
@@ -417,7 +455,7 @@ impl SettingsApp {
             let mut active_count = 0;
             loop {
                 let mut dd: DISPLAY_DEVICEW = std::mem::zeroed();
-                dd.cb = std::mem::size_of::<DISPLAY_DEVICEW>() as u32;
+                dd.cb = size_of::<DISPLAY_DEVICEW>() as u32;
                 if EnumDisplayDevicesW(None, idx, &mut dd, 0).as_bool() {
                     if (dd.StateFlags & DISPLAY_DEVICE_ACTIVE) != 0 {
                         active_count += 1;
@@ -425,7 +463,7 @@ impl SettingsApp {
                             .trim_end_matches('\0')
                             .to_string();
                         let mut dm: DISPLAY_DEVICEW = std::mem::zeroed();
-                        dm.cb = std::mem::size_of::<DISPLAY_DEVICEW>() as u32;
+                        dm.cb = size_of::<DISPLAY_DEVICEW>() as u32;
                         let mut label = if EnumDisplayDevicesW(
                             windows::core::PCWSTR(dd.DeviceName.as_ptr()),
                             0,
@@ -485,6 +523,7 @@ impl SettingsApp {
 
     fn update_detected_apps(&mut self) {
         use windows::Media::Control::GlobalSystemMediaTransportControlsSessionManager;
+        let mut changed = false;
         if let Ok(manager_async) = GlobalSystemMediaTransportControlsSessionManager::RequestAsync()
         {
             if let Ok(manager) = manager_async.get() {
@@ -496,6 +535,7 @@ impl SettingsApp {
                                     let name = id.to_string();
                                     if !self.detected_apps.contains(&name) {
                                         self.detected_apps.push(name);
+                                        changed = true;
                                     }
                                 }
                             }
@@ -507,81 +547,31 @@ impl SettingsApp {
         for app in &self.config.smtc_known_apps {
             if !self.detected_apps.contains(app) {
                 self.detected_apps.push(app.clone());
+                changed = true;
             }
+        }
+        if changed {
+            self.items_dirty = true;
         }
     }
 
     fn draw(&mut self) {
-        let win = self.window.as_ref().unwrap();
-        let size = win.inner_size();
-        let p_w = size.width as i32;
-        let p_h = size.height as i32;
+        let (p_w, p_h, scale) = {
+            let win = self.window.as_ref().unwrap();
+            let size = win.inner_size();
+            (size.width as i32, size.height as i32, win.scale_factor() as f32)
+        };
         if p_w <= 0 || p_h <= 0 {
             return;
         }
-
-        let mut sk_surface = if let Some(ref s) = self.sk_surface {
-            if s.width() == p_w && s.height() == p_h {
-                s.clone()
-            } else {
-                let new_s = surfaces::raster_n32_premul(skia_safe::ISize::new(p_w, p_h)).unwrap();
-                self.sk_surface = Some(new_s.clone());
-                new_s
-            }
-        } else {
-            let new_s = surfaces::raster_n32_premul(skia_safe::ISize::new(p_w, p_h)).unwrap();
-            self.sk_surface = Some(new_s.clone());
-            new_s
+        self.ensure_items_cache();
+        let anim = self.get_page_anim();
+        let mut surface = match self.surface.take() {
+            Some(s) => s,
+            None => return,
         };
 
-        let canvas = sk_surface.canvas();
-        canvas.reset_matrix();
-        canvas.clear(COLOR_WIN_BG);
-        let scale = win.scale_factor() as f32;
-        canvas.scale((scale, scale));
-
-        self.draw_sidebar(canvas);
-
-        let content_w = WIN_W - SIDEBAR_W;
-        canvas.save();
-        canvas.clip_rect(
-            Rect::from_xywh(SIDEBAR_W, 0.0, content_w, WIN_H),
-            skia_safe::ClipOp::Intersect,
-            true,
-        );
-        canvas.translate((SIDEBAR_W, -self.scroll_y));
-
-        let items = self.build_current_items();
-        let anim = self.get_page_anim();
-        draw_items(
-            canvas,
-            &items,
-            CONTENT_START_Y,
-            content_w,
-            &anim,
-            &self.anim,
-        );
-        canvas.restore();
-
-        let ch = content_height(&items, CONTENT_START_Y);
-        let view_h = WIN_H;
-        if ch > view_h {
-            let bar_h = (view_h / ch) * view_h;
-            let bar_y = (self.scroll_y / (ch - view_h)) * (view_h - bar_h);
-            let mut p = Paint::default();
-            p.set_anti_alias(true);
-            p.set_color(Color::from_argb(60, 255, 255, 255));
-            canvas.draw_round_rect(
-                Rect::from_xywh(WIN_W - 6.0, bar_y, 4.0, bar_h),
-                2.0,
-                2.0,
-                &p,
-            );
-        }
-
-        self.draw_popup(canvas);
-
-        if let Some(surface) = self.surface.as_mut() {
+        {
             let mut buffer = surface.buffer_mut().unwrap();
             let info = skia_safe::ImageInfo::new(
                 skia_safe::ISize::new(p_w, p_h),
@@ -591,9 +581,58 @@ impl SettingsApp {
             );
             let dst_row_bytes = (p_w * 4) as usize;
             let u8_buffer: &mut [u8] = bytemuck::cast_slice_mut(&mut *buffer);
-            let _ = sk_surface.read_pixels(&info, u8_buffer, dst_row_bytes, (0, 0));
+            let mut sk_surface =
+                surfaces::wrap_pixels(&info, u8_buffer, dst_row_bytes, None).unwrap();
+
+            let canvas = sk_surface.canvas();
+            canvas.reset_matrix();
+            canvas.clear(COLOR_WIN_BG);
+            canvas.scale((scale, scale));
+
+            self.draw_sidebar(canvas);
+
+            let content_w = WIN_W - SIDEBAR_W;
+            canvas.save();
+            canvas.clip_rect(
+                Rect::from_xywh(SIDEBAR_W, 0.0, content_w, WIN_H),
+                skia_safe::ClipOp::Intersect,
+                true,
+            );
+            canvas.translate((SIDEBAR_W, -self.scroll_y));
+
+            draw_items(
+                canvas,
+                &self.cached_items,
+                CONTENT_START_Y,
+                content_w,
+                &anim,
+                &self.anim,
+                self.scroll_y,
+                self.scroll_y + WIN_H,
+            );
+            canvas.restore();
+
+            let ch = self.cached_content_height;
+            let view_h = WIN_H;
+            if ch > view_h {
+                let bar_h = (view_h / ch) * view_h;
+                let bar_y = (self.scroll_y / (ch - view_h)) * (view_h - bar_h);
+                let mut p = Paint::default();
+                p.set_anti_alias(true);
+                p.set_color(Color::from_argb(60, 255, 255, 255));
+                canvas.draw_round_rect(
+                    Rect::from_xywh(WIN_W - 6.0, bar_y, 4.0, bar_h),
+                    2.0,
+                    2.0,
+                    &p,
+                );
+            }
+
+            self.draw_popup(canvas);
             buffer.present().unwrap();
         }
+
+        self.surface = Some(surface);
     }
 
     fn draw_sidebar(&self, canvas: &skia_safe::Canvas) {
@@ -629,7 +668,7 @@ impl SettingsApp {
                 );
                 paint.set_color(COLOR_TEXT_PRI);
             } else {
-                let hover_val = self.anim.get(&format!("sidebar_{}", i));
+                let hover_val = self.anim.get(SIDEBAR_KEY_BASE + i as u64);
                 if hover_val > 0.005 {
                     let base = color_sidebar_hover();
                     let alpha = (base.a() as f32 * hover_val) as u8;
@@ -660,7 +699,7 @@ impl SettingsApp {
             Some(p) => p,
             None => return,
         };
-        let opacity = self.anim.get("popup_opacity");
+        let opacity = self.anim.get(POPUP_OPACITY_KEY);
         if opacity < 0.005 {
             return;
         }
@@ -806,12 +845,13 @@ impl SettingsApp {
                             }
                         }
                         save_config(&self.config);
+                        self.items_dirty = true;
                         break;
                     }
                 }
             }
             self.popup = None;
-            self.anim.set_with_speed("popup_opacity", 0.0, 0.3);
+            self.anim.set_with_speed(POPUP_OPACITY_KEY, 0.0, 0.3);
             if let Some(win) = &self.window {
                 win.request_redraw();
             }
@@ -832,6 +872,7 @@ impl SettingsApp {
                         self.active_page = i as usize;
                         self.scroll_y = 0.0;
                         self.target_scroll_y = 0.0;
+                        self.items_dirty = true;
                         if let Some(win) = &self.window {
                             win.request_redraw();
                         }
@@ -1027,7 +1068,7 @@ impl SettingsApp {
                             hover_idx: None,
                         });
                     }
-                    self.anim.set_with_speed("popup_opacity", 1.0, 0.25);
+                    self.anim.set_with_speed(POPUP_OPACITY_KEY, 1.0, 0.25);
                     if let Some(win) = &self.window {
                         win.request_redraw();
                     }
@@ -1055,6 +1096,7 @@ impl SettingsApp {
 
         if changed {
             save_config(&self.config);
+            self.items_dirty = true;
             if let Some(win) = &self.window {
                 win.request_redraw();
             }
@@ -1104,7 +1146,7 @@ impl SettingsApp {
                     selected_idx: if source == "163" { 0 } else { 1 },
                     hover_idx: None,
                 });
-                self.anim.set_with_speed("popup_opacity", 1.0, 0.25);
+                self.anim.set_with_speed(POPUP_OPACITY_KEY, 1.0, 0.25);
                 if let Some(win) = &self.window {
                     win.request_redraw();
                 }
@@ -1166,6 +1208,7 @@ impl SettingsApp {
 
         if changed {
             save_config(&self.config);
+            self.items_dirty = true;
             if let Some(win) = &self.window {
                 win.request_redraw();
             }
@@ -1179,7 +1222,7 @@ impl SettingsApp {
         }
     }
 
-    fn get_hover_state(&self) -> bool {
+    fn get_hover_state(&mut self) -> bool {
         let (mx, my) = self.logical_mouse_pos;
 
         if let Some(popup) = &self.popup {
@@ -1207,8 +1250,14 @@ impl SettingsApp {
         let content_x = mx - SIDEBAR_W;
         let content_y = my + self.scroll_y;
         let content_w = WIN_W - SIDEBAR_W;
-        let items = self.build_current_items();
-        hover_test(&items, content_x, content_y, CONTENT_START_Y, content_w)
+        self.ensure_items_cache();
+        hover_test(
+            &self.cached_items,
+            content_x,
+            content_y,
+            CONTENT_START_Y,
+            content_w,
+        )
     }
 }
 
@@ -1300,11 +1349,10 @@ impl ApplicationHandler for SettingsApp {
                 if new_hover != self.sidebar_hover {
                     self.sidebar_hover = new_hover;
                     for idx in 0..3 {
-                        let key = format!("sidebar_{}", idx);
                         if idx == new_hover as usize {
-                            self.anim.set(&key, 1.0);
+                            self.anim.set(SIDEBAR_KEY_BASE + idx as u64, 1.0);
                         } else {
-                            self.anim.set(&key, 0.0);
+                            self.anim.set(SIDEBAR_KEY_BASE + idx as u64, 0.0);
                         }
                     }
                     if let Some(win) = &self.window {
@@ -1316,55 +1364,54 @@ impl ApplicationHandler for SettingsApp {
                     let content_x = mx - SIDEBAR_W;
                     let content_y = my + self.scroll_y;
                     let content_w = WIN_W - SIDEBAR_W;
-                    let items = self.build_current_items();
-                    let mut item_y = CONTENT_START_Y;
                     let mut new_row: Option<usize> = None;
-                    let mut ri: usize = 0;
-                    for item in &items {
-                        if item.is_row() {
-                            if content_y >= item_y
-                                && content_y <= item_y + ROW_HEIGHT
-                                && content_x >= CONTENT_PADDING
-                                && content_x <= content_w - CONTENT_PADDING
-                            {
-                                new_row = Some(ri);
+                    self.ensure_items_cache();
+                    if content_x >= CONTENT_PADDING && content_x <= content_w - CONTENT_PADDING {
+                        let idx = match self
+                            .cached_row_tops
+                            .binary_search_by(|y| y.partial_cmp(&content_y).unwrap())
+                        {
+                            Ok(i) => Some(i),
+                            Err(0) => None,
+                            Err(i) => Some(i - 1),
+                        };
+                        if let Some(i) = idx {
+                            if content_y <= self.cached_row_tops[i] + ROW_HEIGHT {
+                                new_row = Some(i);
                             }
-                            ri += 1;
                         }
-                        item_y += item.height();
                     }
-                    self.total_rows = ri;
                     if new_row != self.hover_row {
                         if let Some(old) = self.hover_row {
-                            self.anim.set(&format!("hover_row_{}", old), 0.0);
+                            self.anim.set(HOVER_ROW_KEY_BASE + old as u64, 0.0);
                         }
                         if let Some(new) = new_row {
-                            self.anim.set(&format!("hover_row_{}", new), 1.0);
+                            self.anim.set(HOVER_ROW_KEY_BASE + new as u64, 1.0);
                         }
                         self.hover_row = new_row;
                     }
                 } else {
                     if self.hover_row.is_some() {
                         if let Some(old) = self.hover_row {
-                            self.anim.set(&format!("hover_row_{}", old), 0.0);
+                            self.anim.set(HOVER_ROW_KEY_BASE + old as u64, 0.0);
                         }
                         self.hover_row = None;
                     }
                 }
 
+                let cursor = if self.get_hover_state() {
+                    winit::window::CursorIcon::Pointer
+                } else {
+                    winit::window::CursorIcon::Default
+                };
                 if let Some(win) = &self.window {
-                    let cursor = if self.get_hover_state() {
-                        winit::window::CursorIcon::Pointer
-                    } else {
-                        winit::window::CursorIcon::Default
-                    };
                     win.set_cursor(cursor);
                 }
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 if self.popup.is_some() {
                     self.popup = None;
-                    self.anim.set_with_speed("popup_opacity", 0.0, 0.3);
+                    self.anim.set_with_speed(POPUP_OPACITY_KEY, 0.0, 0.3);
                     if let Some(win) = &self.window {
                         win.request_redraw();
                     }
@@ -1377,9 +1424,8 @@ impl ApplicationHandler for SettingsApp {
                         winit::event::MouseScrollDelta::PixelDelta(pos) => pos.y as f32,
                     };
                     self.target_scroll_y -= diff;
-                    let items = self.build_current_items();
-                    let ch = content_height(&items, CONTENT_START_Y);
-                    let max_scroll = (ch - WIN_H).max(0.0);
+                    self.ensure_items_cache();
+                    let max_scroll = self.cached_max_scroll;
                     self.target_scroll_y = self.target_scroll_y.clamp(0.0, max_scroll);
                     if let Some(win) = &self.window {
                         win.request_redraw();
@@ -1397,43 +1443,67 @@ impl ApplicationHandler for SettingsApp {
     }
 
     fn about_to_wait(&mut self, _el: &ActiveEventLoop) {
-        if let Some(win) = &self.window {
-            self.frame_count += 1;
-            if self.frame_count % 60 == 0 {
-                unsafe {
-                    let h = OpenMutexW(
-                        MUTEX_ALL_ACCESS,
-                        false,
-                        w!("Local\\WinIsland_SingleInstance_Mutex"),
-                    );
-                    if h.is_err() {
-                        _el.exit();
-                        return;
-                    }
-                    let _ = windows::Win32::Foundation::CloseHandle(h.unwrap());
+        if self.window.is_none() {
+            return;
+        }
+        let frame_start = Instant::now();
+        self.frame_count += 1;
+        if self.frame_count % 60 == 0 {
+            unsafe {
+                let h = OpenMutexW(
+                    MUTEX_ALL_ACCESS,
+                    false,
+                    w!("Local\\WinIsland_SingleInstance_Mutex"),
+                );
+                if h.is_err() {
+                    _el.exit();
+                    return;
                 }
+                let _ = windows::Win32::Foundation::CloseHandle(h.unwrap());
             }
-            let mut redraw = self.switch_anim.tick();
-            if self.anim.tick() {
-                redraw = true;
-            }
+        }
+        let mut redraw = self.switch_anim.tick();
+        if self.anim.tick() {
+            redraw = true;
+        }
 
-            let items = self.build_current_items();
-            let ch = content_height(&items, CONTENT_START_Y);
-            let view_h = WIN_H;
-            let max_scroll = (ch - view_h).max(0.0);
-            self.target_scroll_y = self.target_scroll_y.clamp(0.0, max_scroll);
-            if (self.target_scroll_y - self.scroll_y).abs() > 0.1 {
-                self.scroll_y += (self.target_scroll_y - self.scroll_y) * 0.28;
-                redraw = true;
-            } else if (self.scroll_y - self.target_scroll_y).abs() > f32::EPSILON {
-                self.scroll_y = self.target_scroll_y;
-            }
+        self.ensure_items_cache();
+        let max_scroll = self.cached_max_scroll;
+        self.target_scroll_y = self.target_scroll_y.clamp(0.0, max_scroll);
+        let dt = self.last_frame_time.elapsed().as_secs_f32().clamp(0.001, 0.05);
+        self.last_frame_time = Instant::now();
 
-            if redraw {
+        let stiffness = 55.0;
+        let damping = 16.0;
+        let diff = self.target_scroll_y - self.scroll_y;
+        let accel = diff * stiffness - self.scroll_vel_y * damping;
+        self.scroll_vel_y += accel * dt;
+        self.scroll_y += self.scroll_vel_y * dt;
+
+        if self.scroll_y < 0.0 {
+            self.scroll_y = 0.0;
+            self.scroll_vel_y = 0.0;
+        } else if self.scroll_y > max_scroll {
+            self.scroll_y = max_scroll;
+            self.scroll_vel_y = 0.0;
+        }
+
+        if diff.abs() > 0.05 || self.scroll_vel_y.abs() > 0.05 {
+            redraw = true;
+        } else if (self.scroll_y - self.target_scroll_y).abs() > f32::EPSILON {
+            self.scroll_y = self.target_scroll_y;
+            self.scroll_vel_y = 0.0;
+        }
+
+        if redraw {
+            if let Some(win) = &self.window {
                 win.request_redraw();
             }
-            std::thread::sleep(Duration::from_millis(16));
+            let target = Duration::from_millis(16);
+            let elapsed = frame_start.elapsed();
+            if elapsed < target {
+                std::thread::sleep(target - elapsed);
+            }
         }
     }
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -27,9 +27,11 @@ const SIDEBAR_W: f32 = 180.0;
 const SIDEBAR_ROW_H: f32 = 32.0;
 const CONTENT_START_Y: f32 = 10.0;
 
+const SCROLL_STIFFNESS: f32 = 55.0;
+const SCROLL_DAMPING: f32 = 16.0;
+
 const POPUP_OPACITY_KEY: u64 = 1;
 const SIDEBAR_KEY_BASE: u64 = 1_000;
-const HOVER_ROW_KEY_BASE: u64 = 10_000;
 
 #[derive(Clone, PartialEq)]
 enum PopupKind {
@@ -1473,10 +1475,8 @@ impl ApplicationHandler for SettingsApp {
         let dt = self.last_frame_time.elapsed().as_secs_f32().clamp(0.001, 0.05);
         self.last_frame_time = Instant::now();
 
-        let stiffness = 55.0;
-        let damping = 16.0;
         let diff = self.target_scroll_y - self.scroll_y;
-        let accel = diff * stiffness - self.scroll_vel_y * damping;
+        let accel = diff * SCROLL_STIFFNESS - self.scroll_vel_y * SCROLL_DAMPING;
         self.scroll_vel_y += accel * dt;
         self.scroll_y += self.scroll_vel_y * dt;
 


### PR DESCRIPTION
## 问题
Settings → 常规页右侧列表向下滚动时动画卡顿、FPS 低，滚动期间 CPU 占用明显升高（对比音乐页更明显）。

## 原因分析（概括）
- Settings 渲染走 CPU 光栅化，滚动时会触发高频重绘
- 右侧列表存在较多每帧开销：动画 key 分配、重复构建 items/布局、文本测量/截断重复计算、以及整页绘制（常规页内容更多所以更重）
- 渲染路径原本存在额外的整帧像素拷贝开销（Skia → readback → softbuffer）
## 修复与优化点
- 渲染路径优化 ：直接在 softbuffer 的 back buffer 上创建 Skia surface 绘制，避免 read_pixels 的整帧拷贝
- 列表虚拟绘制 ：仅绘制可见区域附近的 items，减少滚动时每帧绘制量（常规页收益最大）
- 数据与布局缓存
  - 缓存当前页 items、content height、row tops
  - hover row 命中由线性扫描改为基于 row tops 的查找
- 动画与 hover 开销下降
  - AnimPool key 从 String 改为整数 key，避免频繁 format!/分配
- 文字绘制优化 ：Settings 列表中高频文本绘制改为缓存版 draw_text_cached，减少重复测量/截断
- 滚动手感优化 ：滚动从简单 lerp 改为带速度的弹簧模型（更“流体”的 60fps 手感）
## 验证
- cargo check 通过
- 手动验证：常规页滚动更顺滑，CPU 峰值较之前下降，动画手感更接近“流体”