### PR TITLE
feat(settings): add real-time slider for steppers

### DIFF
--- a/src/utils/anim.rs
+++ b/src/utils/anim.rs
@@ -40,6 +40,22 @@ impl AnimPool {
         }
     }
 
+    pub fn set_with_speed_init(&mut self, key: u64, target: f32, speed: f32) {
+        if let Some(v) = self.values.get_mut(&key) {
+            v.target = target;
+            v.speed = speed;
+        } else {
+            self.values.insert(
+                key,
+                AnimValue {
+                    value: target,
+                    target,
+                    speed,
+                },
+            );
+        }
+    }
+
     pub fn get(&self, key: u64) -> f32 {
         self.values.get(&key).map(|v| v.value).unwrap_or(0.0)
     }

--- a/src/utils/anim.rs
+++ b/src/utils/anim.rs
@@ -40,7 +40,7 @@ impl AnimPool {
         }
     }
 
-    pub fn set_with_speed_init(&mut self, key: u64, target: f32, speed: f32) {
+    pub fn set_with_speed_no_transition(&mut self, key: u64, target: f32, speed: f32) {
         if let Some(v) = self.values.get_mut(&key) {
             v.target = target;
             v.speed = speed;

--- a/src/utils/settings_ui/input.rs
+++ b/src/utils/settings_ui/input.rs
@@ -6,6 +6,12 @@ pub enum ClickResult {
     Switch(usize),
     StepperDec(usize),
     StepperInc(usize),
+    StepperSlider {
+        idx: usize,
+        track_x: f32,
+        track_w: f32,
+        t: f32,
+    },
     FontSelect(usize),
     FontReset(usize),
     CenterLink(usize),
@@ -25,7 +31,7 @@ pub fn hit_test(items: &[SettingsItem], mx: f32, my: f32, start_y: f32, width: f
 
     for item in items {
         match item {
-            SettingsItem::RowStepper { enabled, .. } => {
+            SettingsItem::RowStepper { enabled, slider, .. } => {
                 if *enabled {
                     let cy = y + ROW_HEIGHT / 2.0;
                     let btn_inc_x =
@@ -37,6 +43,31 @@ pub fn hit_test(items: &[SettingsItem], mx: f32, my: f32, start_y: f32, width: f
                     }
                     if in_rect(mx, my, btn_inc_x, btn_y, STEPPER_BTN_SIZE, STEPPER_BTN_SIZE) {
                         return ClickResult::StepperInc(idx);
+                    }
+
+                    if slider.is_some() {
+                        let row_x = CONTENT_PADDING + GROUP_INNER_PAD;
+                        let track_x0 = row_x;
+                        let track_x1 = btn_dec_x - 8.0;
+                        let track_w = (track_x1 - track_x0).max(10.0);
+                        let track_y = y + ROW_HEIGHT - STEPPER_SLIDER_BOTTOM_PAD - STEPPER_SLIDER_H;
+                        let hit_pad = STEPPER_SLIDER_KNOB_R + 4.0;
+                        if in_rect(
+                            mx,
+                            my,
+                            track_x0,
+                            track_y - hit_pad,
+                            track_w,
+                            STEPPER_SLIDER_H + hit_pad * 2.0,
+                        ) {
+                            let t = ((mx - track_x0) / track_w).clamp(0.0, 1.0);
+                            return ClickResult::StepperSlider {
+                                idx,
+                                track_x: track_x0,
+                                track_w,
+                                t,
+                            };
+                        }
                     }
                 }
             }

--- a/src/utils/settings_ui/items.rs
+++ b/src/utils/settings_ui/items.rs
@@ -14,6 +14,10 @@ pub const TOGGLE_KNOB: f32 = 18.0;
 pub const TOGGLE_INSET: f32 = 2.0;
 
 pub const STEPPER_BTN_SIZE: f32 = 24.0;
+pub const STEPPER_SLIDER_H: f32 = 4.0;
+pub const STEPPER_SLIDER_R: f32 = 2.0;
+pub const STEPPER_SLIDER_KNOB_R: f32 = 7.0;
+pub const STEPPER_SLIDER_BOTTOM_PAD: f32 = 6.0;
 
 pub const POPUP_BTN_W: f32 = 80.0;
 pub const POPUP_BTN_H: f32 = 26.0;
@@ -21,6 +25,14 @@ pub const POPUP_BTN_R: f32 = 6.0;
 pub const POPUP_ITEM_H: f32 = 28.0;
 pub const POPUP_MENU_R: f32 = 8.0;
 pub const POPUP_MENU_PAD: f32 = 4.0;
+
+#[derive(Clone, Copy, Debug)]
+pub struct SliderSpec {
+    pub min: f32,
+    pub max: f32,
+    pub value: f32,
+    pub step: f32,
+}
 
 pub enum SettingsItem {
     PageTitle {
@@ -35,6 +47,7 @@ pub enum SettingsItem {
         label: String,
         value: String,
         enabled: bool,
+        slider: Option<SliderSpec>,
     },
     RowSwitch {
         label: String,

--- a/src/utils/settings_ui/items.rs
+++ b/src/utils/settings_ui/items.rs
@@ -32,6 +32,7 @@ pub struct SliderSpec {
     pub max: f32,
     pub value: f32,
     pub step: f32,
+    pub config_key: &'static str,
 }
 
 pub enum SettingsItem {

--- a/src/utils/settings_ui/mod.rs
+++ b/src/utils/settings_ui/mod.rs
@@ -4,6 +4,7 @@ pub mod items;
 pub mod renderer;
 
 pub const HOVER_ROW_KEY_BASE: u64 = 10_000;
+pub const SLIDER_KEY_BASE: u64 = 30_000;
 
 pub use anim::SwitchAnimator;
 pub use input::{ClickResult, hit_test, hover_test};

--- a/src/utils/settings_ui/renderer.rs
+++ b/src/utils/settings_ui/renderer.rs
@@ -79,6 +79,54 @@ fn draw_stepper_btn(canvas: &Canvas, x: f32, y: f32, label: &str, enabled: bool)
     );
 }
 
+fn draw_stepper_slider(
+    canvas: &Canvas,
+    x: f32,
+    y: f32,
+    w: f32,
+    spec: SliderSpec,
+    enabled: bool,
+) {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+
+    let denom = (spec.max - spec.min).max(f32::EPSILON);
+    let t = ((spec.value - spec.min) / denom).clamp(0.0, 1.0);
+    let knob_x = x + t * w;
+
+    paint.set_color(if enabled {
+        Color::from_argb(40, 255, 255, 255)
+    } else {
+        Color::from_argb(22, 255, 255, 255)
+    });
+    canvas.draw_round_rect(
+        Rect::from_xywh(x, y, w, STEPPER_SLIDER_H),
+        STEPPER_SLIDER_R,
+        STEPPER_SLIDER_R,
+        &paint,
+    );
+
+    paint.set_color(if enabled { COLOR_TOGGLE_ON } else { COLOR_DISABLED });
+    canvas.draw_round_rect(
+        Rect::from_xywh(x, y, w * t, STEPPER_SLIDER_H),
+        STEPPER_SLIDER_R,
+        STEPPER_SLIDER_R,
+        &paint,
+    );
+
+    let mut shadow = Paint::default();
+    shadow.set_anti_alias(true);
+    shadow.set_color(Color::from_argb(35, 0, 0, 0));
+    canvas.draw_circle(
+        (knob_x, y + STEPPER_SLIDER_H / 2.0 + 1.0),
+        STEPPER_SLIDER_KNOB_R,
+        &shadow,
+    );
+
+    paint.set_color(Color::WHITE);
+    canvas.draw_circle((knob_x, y + STEPPER_SLIDER_H / 2.0), STEPPER_SLIDER_KNOB_R, &paint);
+}
+
 fn draw_pill_btn(
     canvas: &Canvas,
     x: f32,
@@ -152,6 +200,7 @@ pub fn draw_items(
     width: f32,
     anims: &SwitchAnimator,
     hover_anims: &AnimPool,
+    slider_key_base: u64,
     visible_min_y: f32,
     visible_max_y: f32,
 ) {
@@ -229,6 +278,7 @@ pub fn draw_items(
                 label,
                 value,
                 enabled,
+                slider,
             } => {
                 if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
                     draw_row_hover(canvas, y, content_w, row_idx, in_group, hover_anims);
@@ -279,6 +329,20 @@ pub fn draw_items(
                         true,
                         f32::MAX,
                     );
+                }
+
+                if let Some(spec) = slider {
+                    let track_x0 = row_x;
+                    let track_x1 = btn_dec_x - 8.0;
+                    let track_w = (track_x1 - track_x0).max(10.0);
+                    let track_y = y + ROW_HEIGHT - STEPPER_SLIDER_BOTTOM_PAD - STEPPER_SLIDER_H;
+                    if y + ROW_HEIGHT >= visible_min_y && y <= visible_max_y {
+                        let key = slider_key_base + i as u64;
+                        let mut spec = *spec;
+                        let denom = (spec.max - spec.min).max(f32::EPSILON);
+                        spec.value = spec.min + denom * hover_anims.get(key).clamp(0.0, 1.0);
+                        draw_stepper_slider(canvas, track_x0, track_y, track_w, spec, *enabled);
+                    }
                 }
 
                 if in_group {

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -80,6 +80,22 @@ impl PopupState {
     }
 }
 
+#[derive(Clone, Copy)]
+struct StepperSliderSpec {
+    spec: SliderSpec,
+    track_x: f32,
+    track_w: f32,
+}
+
+struct StepperSliderDrag {
+    page: usize,
+    label: String,
+    spec: StepperSliderSpec,
+    changed: bool,
+    pending_save: bool,
+    last_save: Instant,
+}
+
 pub struct SettingsApp {
     window: Option<Arc<Window>>,
     surface: Option<Surface<Arc<Window>, Arc<Window>>>,
@@ -103,6 +119,7 @@ pub struct SettingsApp {
     cached_content_height: f32,
     cached_max_scroll: f32,
     cached_row_tops: Vec<f32>,
+    stepper_slider_drag: Option<StepperSliderDrag>,
 }
 
 impl SettingsApp {
@@ -141,6 +158,138 @@ impl SettingsApp {
             cached_content_height: 0.0,
             cached_max_scroll: 0.0,
             cached_row_tops: Vec::new(),
+            stepper_slider_drag: None,
+        }
+    }
+
+    fn quantize_slider_value(v: f32, step: f32) -> f32 {
+        if step > 0.0 {
+            (v / step).round() * step
+        } else {
+            v
+        }
+    }
+
+    fn apply_stepper_slider_value(&mut self, page: usize, label: &str, spec: SliderSpec, t: f32) -> bool {
+        let raw = spec.min + (spec.max - spec.min) * t.clamp(0.0, 1.0);
+        let mut v = Self::quantize_slider_value(raw, spec.step).clamp(spec.min, spec.max);
+
+        if page == 0 {
+            if label == tr("global_scale") {
+                v = (v * 100.0).round() / 100.0;
+                if (self.config.global_scale - v).abs() > 0.0001 {
+                    self.config.global_scale = v;
+                    return true;
+                }
+            } else if label == tr("base_width") {
+                if (self.config.base_width - v).abs() > 0.0001 {
+                    self.config.base_width = v;
+                    return true;
+                }
+            } else if label == tr("base_height") {
+                if (self.config.base_height - v).abs() > 0.0001 {
+                    self.config.base_height = v;
+                    return true;
+                }
+            } else if label == tr("expanded_width") {
+                if (self.config.expanded_width - v).abs() > 0.0001 {
+                    self.config.expanded_width = v;
+                    return true;
+                }
+            } else if label == tr("expanded_height") {
+                if (self.config.expanded_height - v).abs() > 0.0001 {
+                    self.config.expanded_height = v;
+                    return true;
+                }
+            } else if label == tr("position_x_offset") {
+                let vi = v.round() as i32;
+                if self.config.position_x_offset != vi {
+                    self.config.position_x_offset = vi;
+                    return true;
+                }
+            } else if label == tr("position_y_offset") {
+                let vi = v.round() as i32;
+                if self.config.position_y_offset != vi {
+                    self.config.position_y_offset = vi;
+                    return true;
+                }
+            } else if label == tr("font_size") {
+                v = v.round();
+                if (self.config.font_size - v).abs() > 0.0001 {
+                    self.config.font_size = v;
+                    return true;
+                }
+            } else if label == tr("hide_delay") {
+                v = v.round();
+                if (self.config.auto_hide_delay - v).abs() > 0.0001 {
+                    self.config.auto_hide_delay = v;
+                    return true;
+                }
+            } else if label == tr("update_interval") {
+                v = v.round();
+                if (self.config.update_check_interval - v).abs() > 0.0001 {
+                    self.config.update_check_interval = v;
+                    return true;
+                }
+            }
+        } else if page == 1 {
+            if label == tr("lyrics_delay") {
+                v = (v * 10.0).round() / 10.0;
+                let vf = v as f64;
+                if (self.config.lyrics_delay - vf).abs() > 0.0001 {
+                    self.config.lyrics_delay = vf;
+                    return true;
+                }
+            } else if label == tr("lyrics_scroll_max_width") {
+                v = v.round();
+                if (self.config.lyrics_scroll_max_width - v).abs() > 0.0001 {
+                    self.config.lyrics_scroll_max_width = v;
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn end_stepper_slider_drag(&mut self) {
+        if let Some(drag) = &self.stepper_slider_drag {
+            if drag.pending_save {
+                save_config(&self.config);
+                self.items_dirty = true;
+            }
+        }
+        self.stepper_slider_drag = None;
+        if let Some(win) = &self.window {
+            win.request_redraw();
+        }
+    }
+
+    fn sync_stepper_slider_anims(&mut self, slider_key_base: u64) {
+        for (i, item) in self.cached_items.iter().enumerate() {
+            if let SettingsItem::RowStepper {
+                label,
+                enabled,
+                slider: Some(spec),
+                ..
+            } = item
+            {
+                if !*enabled {
+                    continue;
+                }
+                let denom = (spec.max - spec.min).max(f32::EPSILON);
+                let t = ((spec.value - spec.min) / denom).clamp(0.0, 1.0);
+                let key = slider_key_base + i as u64;
+                let speed = if self
+                    .stepper_slider_drag
+                    .as_ref()
+                    .is_some_and(|d| d.label == *label)
+                {
+                    1.0
+                } else {
+                    0.22
+                };
+                self.anim.set_with_speed_init(key, t, speed);
+            }
         }
     }
 
@@ -157,41 +306,89 @@ impl SettingsApp {
                 label: tr("global_scale"),
                 value: format!("{:.2}", self.config.global_scale),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 0.5,
+                    max: 5.0,
+                    value: self.config.global_scale,
+                    step: 0.01,
+                }),
             },
             SettingsItem::RowStepper {
                 label: tr("base_width"),
                 value: self.config.base_width.to_string(),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 60.0,
+                    max: 600.0,
+                    value: self.config.base_width,
+                    step: 1.0,
+                }),
             },
             SettingsItem::RowStepper {
                 label: tr("base_height"),
                 value: self.config.base_height.to_string(),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 20.0,
+                    max: 200.0,
+                    value: self.config.base_height,
+                    step: 1.0,
+                }),
             },
             SettingsItem::RowStepper {
                 label: tr("expanded_width"),
                 value: self.config.expanded_width.to_string(),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 200.0,
+                    max: 1200.0,
+                    value: self.config.expanded_width,
+                    step: 1.0,
+                }),
             },
             SettingsItem::RowStepper {
                 label: tr("expanded_height"),
                 value: self.config.expanded_height.to_string(),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 100.0,
+                    max: 900.0,
+                    value: self.config.expanded_height,
+                    step: 1.0,
+                }),
             },
             SettingsItem::RowStepper {
                 label: tr("position_x_offset"),
                 value: self.config.position_x_offset.to_string(),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: -500.0,
+                    max: 500.0,
+                    value: self.config.position_x_offset as f32,
+                    step: 1.0,
+                }),
             },
             SettingsItem::RowStepper {
                 label: tr("position_y_offset"),
                 value: self.config.position_y_offset.to_string(),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: -500.0,
+                    max: 500.0,
+                    value: self.config.position_y_offset as f32,
+                    step: 1.0,
+                }),
             },
             SettingsItem::RowStepper {
                 label: tr("font_size"),
                 value: format!("{:.0}", self.config.font_size),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 0.0,
+                    max: 30.0,
+                    value: self.config.font_size,
+                    step: 1.0,
+                }),
             },
         ];
         {
@@ -261,6 +458,12 @@ impl SettingsApp {
                 label: tr("hide_delay"),
                 value: format!("{:.0}", self.config.auto_hide_delay),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 1.0,
+                    max: 60.0,
+                    value: self.config.auto_hide_delay,
+                    step: 1.0,
+                }),
             });
         }
         items.push(SettingsItem::RowSourceSelect {
@@ -287,6 +490,12 @@ impl SettingsApp {
                 label: tr("update_interval"),
                 value: format!("{:.0}", self.config.update_check_interval),
                 enabled: true,
+                slider: Some(SliderSpec {
+                    min: 1.0,
+                    max: 24.0,
+                    value: self.config.update_check_interval,
+                    step: 1.0,
+                }),
             });
         }
         items.push(SettingsItem::GroupEnd);
@@ -348,6 +557,12 @@ impl SettingsApp {
                 label: tr("lyrics_delay"),
                 value: format!("{:.1}", self.config.lyrics_delay),
                 enabled: show_lyrics,
+                slider: Some(SliderSpec {
+                    min: -10.0,
+                    max: 10.0,
+                    value: self.config.lyrics_delay as f32,
+                    step: 0.1,
+                }),
             },
             SettingsItem::RowSwitch {
                 label: tr("lyrics_scroll"),
@@ -362,6 +577,12 @@ impl SettingsApp {
                 label: tr("lyrics_scroll_max_width"),
                 value: format!("{}", self.config.lyrics_scroll_max_width as i32),
                 enabled: show_lyrics && self.config.lyrics_scroll,
+                slider: Some(SliderSpec {
+                    min: 100.0,
+                    max: 500.0,
+                    value: self.config.lyrics_scroll_max_width,
+                    step: 1.0,
+                }),
             },
             SettingsItem::GroupEnd,
             SettingsItem::SectionHeader {
@@ -567,6 +788,8 @@ impl SettingsApp {
             return;
         }
         self.ensure_items_cache();
+        let slider_key_base = SLIDER_KEY_BASE + self.active_page as u64 * 100_000;
+        self.sync_stepper_slider_anims(slider_key_base);
         let anim = self.get_page_anim();
         let mut surface = match self.surface.take() {
             Some(s) => s,
@@ -609,6 +832,7 @@ impl SettingsApp {
                 content_w,
                 &anim,
                 &self.anim,
+                slider_key_base,
                 self.scroll_y,
                 self.scroll_y + WIN_H,
             );
@@ -903,6 +1127,47 @@ impl SettingsApp {
         let mut changed = false;
 
         match result {
+            ClickResult::StepperSlider {
+                idx,
+                track_x,
+                track_w,
+                t,
+            } => {
+                if let Some(SettingsItem::RowStepper {
+                    label,
+                    enabled,
+                    slider: Some(spec),
+                    ..
+                }) = items.get(idx)
+                {
+                    if *enabled {
+                        let spec = StepperSliderSpec {
+                            spec: *spec,
+                            track_x,
+                            track_w,
+                        };
+                        let did = self.apply_stepper_slider_value(0, label, spec.spec, t);
+                        if did {
+                            save_config(&self.config);
+                        }
+                        self.stepper_slider_drag = Some(StepperSliderDrag {
+                            page: 0,
+                            label: label.clone(),
+                            spec,
+                            changed: did,
+                            pending_save: false,
+                            last_save: Instant::now(),
+                        });
+                        if did {
+                            self.items_dirty = true;
+                        }
+                        if let Some(win) = &self.window {
+                            win.request_redraw();
+                        }
+                    }
+                }
+                return;
+            }
             ClickResult::StepperDec(idx) | ClickResult::StepperInc(idx) => {
                 let is_dec = matches!(result, ClickResult::StepperDec(_));
                 if let Some(item) = items.get(idx) {
@@ -1110,6 +1375,47 @@ impl SettingsApp {
         let mut changed = false;
 
         match result {
+            ClickResult::StepperSlider {
+                idx,
+                track_x,
+                track_w,
+                t,
+            } => {
+                if let Some(SettingsItem::RowStepper {
+                    label,
+                    enabled,
+                    slider: Some(spec),
+                    ..
+                }) = items.get(idx)
+                {
+                    if *enabled {
+                        let spec = StepperSliderSpec {
+                            spec: *spec,
+                            track_x,
+                            track_w,
+                        };
+                        let did = self.apply_stepper_slider_value(1, label, spec.spec, t);
+                        if did {
+                            save_config(&self.config);
+                        }
+                        self.stepper_slider_drag = Some(StepperSliderDrag {
+                            page: 1,
+                            label: label.clone(),
+                            spec,
+                            changed: did,
+                            pending_save: false,
+                            last_save: Instant::now(),
+                        });
+                        if did {
+                            self.items_dirty = true;
+                        }
+                        if let Some(win) = &self.window {
+                            win.request_redraw();
+                        }
+                    }
+                }
+                return;
+            }
             ClickResult::Switch(idx) => {
                 match idx {
                     0 => self.config.smtc_enabled = !self.config.smtc_enabled,
@@ -1308,6 +1614,40 @@ impl ApplicationHandler for SettingsApp {
                 let scale = self.window.as_ref().unwrap().scale_factor() as f32;
                 self.logical_mouse_pos = (position.x as f32 / scale, position.y as f32 / scale);
 
+                if self.stepper_slider_drag.is_some() {
+                    let (page, label, spec, track_x, track_w, last_save) = {
+                        let drag = self.stepper_slider_drag.as_ref().unwrap();
+                        (
+                            drag.page,
+                            drag.label.clone(),
+                            drag.spec.spec,
+                            drag.spec.track_x,
+                            drag.spec.track_w,
+                            drag.last_save,
+                        )
+                    };
+                    let (mx, _) = self.logical_mouse_pos;
+                    let content_x = mx - SIDEBAR_W;
+                    let t = ((content_x - track_x) / track_w).clamp(0.0, 1.0);
+                    let did = self.apply_stepper_slider_value(page, &label, spec, t);
+                    if did {
+                        if let Some(drag) = &mut self.stepper_slider_drag {
+                            drag.changed = true;
+                            drag.pending_save = true;
+                            self.items_dirty = true;
+                            if last_save.elapsed() >= Duration::from_millis(40) {
+                                save_config(&self.config);
+                                drag.pending_save = false;
+                                drag.last_save = Instant::now();
+                            }
+                            if let Some(win) = &self.window {
+                                win.request_redraw();
+                            }
+                        }
+                    }
+                    return;
+                }
+
                 if let Some(popup) = &mut self.popup {
                     let (pmx, pmy) = self.logical_mouse_pos;
                     let menu = popup.menu_rect();
@@ -1439,6 +1779,11 @@ impl ApplicationHandler for SettingsApp {
                 button: MouseButton::Left,
                 ..
             } => self.handle_click(),
+            WindowEvent::MouseInput {
+                state: ElementState::Released,
+                button: MouseButton::Left,
+                ..
+            } => self.end_stepper_slider_drag(),
             WindowEvent::RedrawRequested => self.draw(),
             _ => (),
         }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -32,6 +32,8 @@ const SCROLL_DAMPING: f32 = 16.0;
 
 const POPUP_OPACITY_KEY: u64 = 1;
 const SIDEBAR_KEY_BASE: u64 = 1_000;
+const SLIDER_SAVE_THROTTLE_MS: u64 = 40;
+const SLIDER_PAGE_KEY_STRIDE: u64 = 100_000;
 
 #[derive(Clone, PartialEq)]
 enum PopupKind {
@@ -88,8 +90,6 @@ struct StepperSliderSpec {
 }
 
 struct StepperSliderDrag {
-    page: usize,
-    label: String,
     spec: StepperSliderSpec,
     changed: bool,
     pending_save: bool,
@@ -170,83 +170,93 @@ impl SettingsApp {
         }
     }
 
-    fn apply_stepper_slider_value(&mut self, page: usize, label: &str, spec: SliderSpec, t: f32) -> bool {
+    fn apply_stepper_slider_value(&mut self, config_key: &str, spec: SliderSpec, t: f32) -> bool {
         let raw = spec.min + (spec.max - spec.min) * t.clamp(0.0, 1.0);
         let mut v = Self::quantize_slider_value(raw, spec.step).clamp(spec.min, spec.max);
 
-        if page == 0 {
-            if label == tr("global_scale") {
+        match config_key {
+            "global_scale" => {
                 v = (v * 100.0).round() / 100.0;
                 if (self.config.global_scale - v).abs() > 0.0001 {
                     self.config.global_scale = v;
                     return true;
                 }
-            } else if label == tr("base_width") {
+            }
+            "base_width" => {
                 if (self.config.base_width - v).abs() > 0.0001 {
                     self.config.base_width = v;
                     return true;
                 }
-            } else if label == tr("base_height") {
+            }
+            "base_height" => {
                 if (self.config.base_height - v).abs() > 0.0001 {
                     self.config.base_height = v;
                     return true;
                 }
-            } else if label == tr("expanded_width") {
+            }
+            "expanded_width" => {
                 if (self.config.expanded_width - v).abs() > 0.0001 {
                     self.config.expanded_width = v;
                     return true;
                 }
-            } else if label == tr("expanded_height") {
+            }
+            "expanded_height" => {
                 if (self.config.expanded_height - v).abs() > 0.0001 {
                     self.config.expanded_height = v;
                     return true;
                 }
-            } else if label == tr("position_x_offset") {
+            }
+            "position_x_offset" => {
                 let vi = v.round() as i32;
                 if self.config.position_x_offset != vi {
                     self.config.position_x_offset = vi;
                     return true;
                 }
-            } else if label == tr("position_y_offset") {
+            }
+            "position_y_offset" => {
                 let vi = v.round() as i32;
                 if self.config.position_y_offset != vi {
                     self.config.position_y_offset = vi;
                     return true;
                 }
-            } else if label == tr("font_size") {
+            }
+            "font_size" => {
                 v = v.round();
                 if (self.config.font_size - v).abs() > 0.0001 {
                     self.config.font_size = v;
                     return true;
                 }
-            } else if label == tr("hide_delay") {
+            }
+            "auto_hide_delay" => {
                 v = v.round();
                 if (self.config.auto_hide_delay - v).abs() > 0.0001 {
                     self.config.auto_hide_delay = v;
                     return true;
                 }
-            } else if label == tr("update_interval") {
+            }
+            "update_check_interval" => {
                 v = v.round();
                 if (self.config.update_check_interval - v).abs() > 0.0001 {
                     self.config.update_check_interval = v;
                     return true;
                 }
             }
-        } else if page == 1 {
-            if label == tr("lyrics_delay") {
+            "lyrics_delay" => {
                 v = (v * 10.0).round() / 10.0;
                 let vf = v as f64;
                 if (self.config.lyrics_delay - vf).abs() > 0.0001 {
                     self.config.lyrics_delay = vf;
                     return true;
                 }
-            } else if label == tr("lyrics_scroll_max_width") {
+            }
+            "lyrics_scroll_max_width" => {
                 v = v.round();
                 if (self.config.lyrics_scroll_max_width - v).abs() > 0.0001 {
                     self.config.lyrics_scroll_max_width = v;
                     return true;
                 }
             }
+            _ => {}
         }
         false
     }
@@ -264,10 +274,52 @@ impl SettingsApp {
         }
     }
 
+    fn start_slider_drag(
+        &mut self,
+        items: &[SettingsItem],
+        idx: usize,
+        track_x: f32,
+        track_w: f32,
+        t: f32,
+    ) {
+        if let Some(SettingsItem::RowStepper {
+            enabled,
+            slider: Some(spec),
+            ..
+        }) = items.get(idx)
+        {
+            if !*enabled {
+                return;
+            }
+            let spec = StepperSliderSpec {
+                spec: *spec,
+                track_x,
+                track_w,
+            };
+            let did = self.apply_stepper_slider_value(spec.spec.config_key, spec.spec, t);
+            if did {
+                save_config(&self.config);
+                self.items_dirty = true;
+            }
+            self.stepper_slider_drag = Some(StepperSliderDrag {
+                spec,
+                changed: did,
+                pending_save: false,
+                last_save: Instant::now(),
+            });
+            if let Some(win) = &self.window {
+                win.request_redraw();
+            }
+        }
+    }
+
     fn sync_stepper_slider_anims(&mut self, slider_key_base: u64) {
+        let dragging_key = self
+            .stepper_slider_drag
+            .as_ref()
+            .map(|d| d.spec.spec.config_key);
         for (i, item) in self.cached_items.iter().enumerate() {
             if let SettingsItem::RowStepper {
-                label,
                 enabled,
                 slider: Some(spec),
                 ..
@@ -279,16 +331,12 @@ impl SettingsApp {
                 let denom = (spec.max - spec.min).max(f32::EPSILON);
                 let t = ((spec.value - spec.min) / denom).clamp(0.0, 1.0);
                 let key = slider_key_base + i as u64;
-                let speed = if self
-                    .stepper_slider_drag
-                    .as_ref()
-                    .is_some_and(|d| d.label == *label)
-                {
+                let speed = if dragging_key == Some(spec.config_key) {
                     1.0
                 } else {
                     0.22
                 };
-                self.anim.set_with_speed_init(key, t, speed);
+                self.anim.set_with_speed_no_transition(key, t, speed);
             }
         }
     }
@@ -311,6 +359,7 @@ impl SettingsApp {
                     max: 5.0,
                     value: self.config.global_scale,
                     step: 0.01,
+                    config_key: "global_scale",
                 }),
             },
             SettingsItem::RowStepper {
@@ -322,6 +371,7 @@ impl SettingsApp {
                     max: 600.0,
                     value: self.config.base_width,
                     step: 1.0,
+                    config_key: "base_width",
                 }),
             },
             SettingsItem::RowStepper {
@@ -333,6 +383,7 @@ impl SettingsApp {
                     max: 200.0,
                     value: self.config.base_height,
                     step: 1.0,
+                    config_key: "base_height",
                 }),
             },
             SettingsItem::RowStepper {
@@ -344,6 +395,7 @@ impl SettingsApp {
                     max: 1200.0,
                     value: self.config.expanded_width,
                     step: 1.0,
+                    config_key: "expanded_width",
                 }),
             },
             SettingsItem::RowStepper {
@@ -355,6 +407,7 @@ impl SettingsApp {
                     max: 900.0,
                     value: self.config.expanded_height,
                     step: 1.0,
+                    config_key: "expanded_height",
                 }),
             },
             SettingsItem::RowStepper {
@@ -366,6 +419,7 @@ impl SettingsApp {
                     max: 500.0,
                     value: self.config.position_x_offset as f32,
                     step: 1.0,
+                    config_key: "position_x_offset",
                 }),
             },
             SettingsItem::RowStepper {
@@ -377,6 +431,7 @@ impl SettingsApp {
                     max: 500.0,
                     value: self.config.position_y_offset as f32,
                     step: 1.0,
+                    config_key: "position_y_offset",
                 }),
             },
             SettingsItem::RowStepper {
@@ -388,6 +443,7 @@ impl SettingsApp {
                     max: 30.0,
                     value: self.config.font_size,
                     step: 1.0,
+                    config_key: "font_size",
                 }),
             },
         ];
@@ -463,6 +519,7 @@ impl SettingsApp {
                     max: 60.0,
                     value: self.config.auto_hide_delay,
                     step: 1.0,
+                    config_key: "auto_hide_delay",
                 }),
             });
         }
@@ -495,6 +552,7 @@ impl SettingsApp {
                     max: 24.0,
                     value: self.config.update_check_interval,
                     step: 1.0,
+                    config_key: "update_check_interval",
                 }),
             });
         }
@@ -562,6 +620,7 @@ impl SettingsApp {
                     max: 10.0,
                     value: self.config.lyrics_delay as f32,
                     step: 0.1,
+                    config_key: "lyrics_delay",
                 }),
             },
             SettingsItem::RowSwitch {
@@ -582,6 +641,7 @@ impl SettingsApp {
                     max: 500.0,
                     value: self.config.lyrics_scroll_max_width,
                     step: 1.0,
+                    config_key: "lyrics_scroll_max_width",
                 }),
             },
             SettingsItem::GroupEnd,
@@ -788,7 +848,8 @@ impl SettingsApp {
             return;
         }
         self.ensure_items_cache();
-        let slider_key_base = SLIDER_KEY_BASE + self.active_page as u64 * 100_000;
+        let slider_key_base =
+            SLIDER_KEY_BASE + self.active_page as u64 * SLIDER_PAGE_KEY_STRIDE;
         self.sync_stepper_slider_anims(slider_key_base);
         let anim = self.get_page_anim();
         let mut surface = match self.surface.take() {
@@ -1133,39 +1194,7 @@ impl SettingsApp {
                 track_w,
                 t,
             } => {
-                if let Some(SettingsItem::RowStepper {
-                    label,
-                    enabled,
-                    slider: Some(spec),
-                    ..
-                }) = items.get(idx)
-                {
-                    if *enabled {
-                        let spec = StepperSliderSpec {
-                            spec: *spec,
-                            track_x,
-                            track_w,
-                        };
-                        let did = self.apply_stepper_slider_value(0, label, spec.spec, t);
-                        if did {
-                            save_config(&self.config);
-                        }
-                        self.stepper_slider_drag = Some(StepperSliderDrag {
-                            page: 0,
-                            label: label.clone(),
-                            spec,
-                            changed: did,
-                            pending_save: false,
-                            last_save: Instant::now(),
-                        });
-                        if did {
-                            self.items_dirty = true;
-                        }
-                        if let Some(win) = &self.window {
-                            win.request_redraw();
-                        }
-                    }
-                }
+                self.start_slider_drag(items, idx, track_x, track_w, t);
                 return;
             }
             ClickResult::StepperDec(idx) | ClickResult::StepperInc(idx) => {
@@ -1381,39 +1410,7 @@ impl SettingsApp {
                 track_w,
                 t,
             } => {
-                if let Some(SettingsItem::RowStepper {
-                    label,
-                    enabled,
-                    slider: Some(spec),
-                    ..
-                }) = items.get(idx)
-                {
-                    if *enabled {
-                        let spec = StepperSliderSpec {
-                            spec: *spec,
-                            track_x,
-                            track_w,
-                        };
-                        let did = self.apply_stepper_slider_value(1, label, spec.spec, t);
-                        if did {
-                            save_config(&self.config);
-                        }
-                        self.stepper_slider_drag = Some(StepperSliderDrag {
-                            page: 1,
-                            label: label.clone(),
-                            spec,
-                            changed: did,
-                            pending_save: false,
-                            last_save: Instant::now(),
-                        });
-                        if did {
-                            self.items_dirty = true;
-                        }
-                        if let Some(win) = &self.window {
-                            win.request_redraw();
-                        }
-                    }
-                }
+                self.start_slider_drag(items, idx, track_x, track_w, t);
                 return;
             }
             ClickResult::Switch(idx) => {
@@ -1615,11 +1612,9 @@ impl ApplicationHandler for SettingsApp {
                 self.logical_mouse_pos = (position.x as f32 / scale, position.y as f32 / scale);
 
                 if self.stepper_slider_drag.is_some() {
-                    let (page, label, spec, track_x, track_w, last_save) = {
+                    let (spec, track_x, track_w, last_save) = {
                         let drag = self.stepper_slider_drag.as_ref().unwrap();
                         (
-                            drag.page,
-                            drag.label.clone(),
                             drag.spec.spec,
                             drag.spec.track_x,
                             drag.spec.track_w,
@@ -1629,13 +1624,14 @@ impl ApplicationHandler for SettingsApp {
                     let (mx, _) = self.logical_mouse_pos;
                     let content_x = mx - SIDEBAR_W;
                     let t = ((content_x - track_x) / track_w).clamp(0.0, 1.0);
-                    let did = self.apply_stepper_slider_value(page, &label, spec, t);
+                    let did = self.apply_stepper_slider_value(spec.config_key, spec, t);
                     if did {
                         if let Some(drag) = &mut self.stepper_slider_drag {
                             drag.changed = true;
                             drag.pending_save = true;
                             self.items_dirty = true;
-                            if last_save.elapsed() >= Duration::from_millis(40) {
+                            if last_save.elapsed() >= Duration::from_millis(SLIDER_SAVE_THROTTLE_MS)
+                            {
                                 save_config(&self.config);
                                 drag.pending_save = false;
                                 drag.last_save = Instant::now();


### PR DESCRIPTION
## 问题
目前设置项的数值只能通过 + / - 逐步调整，想精确到目标值会比较费劲。希望在数值项下方增加滑条（scroll bar/slider）之类的交互，让调整更容易，并且拖动时实时生效。

close #35 

## 变更内容
- 为数值型设置项增加滑条（保留原有 + / - ，不改变原操作习惯）
- 拖拽滑条时数值实时更新、即时生效（real-time）
- 点击滑条轨道或使用 + / - 时提供平滑过渡，尽量贴近 iOS 风格；拖拽保持跟手
- 拖拽过程中对配置写盘做节流，减少频繁保存带来的开销；松手后确保最终值落盘
## 实现说明（简要）
- 扩展 SettingsItem::RowStepper ：增加可选 slider 参数（min/max/value/step）
- 渲染层绘制细轨道 + 已填充部分 + 圆形滑块（iOS 风格）
- 输入层增加 slider 轨道命中与拖拽处理
- Settings 窗口维护拖拽状态：移动时持续更新对应配置并触发重绘；按节流策略保存配置
## 验证
- cargo build 通过
- 手动验证：
  - Settings → 常规/音乐：拖动滑条时数值实时变化并立即生效
  - 点击轨道 / 点击 + / - ：滑块平滑移动到新位置
  - 关闭设置窗口后重新打开：数值保持为调整后的结果
  - 被禁用的条目不响应滑条（例如某些开关关闭时的相关项）