### PR TITLE
fix: prevent multiple settings windows from opening simultaneously

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,13 @@ fn main() {
 
     let args: Vec<String> = env::args().collect();
     if args.iter().any(|arg| arg == "--settings") {
+        unsafe {
+            let _ = CreateMutexW(None, true, w!("Local\\WinIsland_Settings_Mutex"));
+            if GetLastError() == ERROR_ALREADY_EXISTS {
+                crate::window::settings::bring_settings_to_front();
+                return;
+            }
+        }
         window::settings::run_settings(config);
     } else {
         unsafe {

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -23,6 +23,7 @@ use crate::utils::mouse::{
 use crate::utils::physics::Spring;
 use crate::window::tray::{TrayAction, TrayManager};
 use softbuffer::{Context, Surface};
+use std::cell::RefCell;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -91,6 +92,7 @@ pub struct App {
     touch_id: Option<u64>,
     touch_pos: PhysicalPosition<f64>,
     plugin_mgr: PluginManager,
+    settings_process: RefCell<Option<std::process::Child>>,
 }
 
 impl Default for App {
@@ -150,6 +152,7 @@ impl Default for App {
             touch_id: None,
             touch_pos: PhysicalPosition::new(0.0, 0.0),
             plugin_mgr: PluginManager::default(),
+            settings_process: RefCell::new(None),
         }
     }
 }
@@ -395,9 +398,7 @@ impl App {
                     let gear_y = island_y + h - 28.0 * scale;
                     let dist_sq = (rel_x as f64 - gear_x).powi(2) + (rel_y as f64 - gear_y).powi(2);
                     if dist_sq <= (20.0 * scale).powi(2) {
-                        let _ = std::process::Command::new(std::env::current_exe().unwrap())
-                            .arg("--settings")
-                            .spawn();
+                        self.open_settings();
                         return;
                     }
 
@@ -519,6 +520,30 @@ impl App {
 
         if let Err(e) = notifier.Show(&toast) {
             log::error!("Toast Show failed: {:?}", e);
+        }
+    }
+
+    fn open_settings(&self) {
+        let mut proc = self.settings_process.borrow_mut();
+        if let Some(ref mut child) = *proc {
+            match child.try_wait() {
+                Ok(Some(_)) => {
+                    *proc = None;
+                }
+                Ok(None) => {
+                    crate::window::settings::bring_settings_to_front();
+                    return;
+                }
+                Err(_) => {
+                    *proc = None;
+                }
+            }
+        }
+        let result = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--settings")
+            .spawn();
+        if let Ok(child) = result {
+            *proc = Some(child);
         }
     }
 
@@ -769,9 +794,7 @@ impl ApplicationHandler for App {
                         tray.update_item_text(self.visible);
                     }
                     Some(TrayAction::OpenSettings) => {
-                        let _ = std::process::Command::new(std::env::current_exe().unwrap())
-                            .arg("--settings")
-                            .spawn();
+                        self.open_settings();
                     }
                     Some(TrayAction::Exit) => {
                         event_loop.exit();

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -797,6 +797,9 @@ impl ApplicationHandler for App {
                         self.open_settings();
                     }
                     Some(TrayAction::Exit) => {
+                        if let Some(mut settings) = self.settings_process.borrow_mut().take() {
+                            let _ = settings.kill();
+                        }
                         event_loop.exit();
                     }
                     None => (),

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -13,6 +13,9 @@ use softbuffer::{Context, Surface};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use windows::Win32::System::Threading::{MUTEX_ALL_ACCESS, OpenMutexW};
+use windows::Win32::UI::WindowsAndMessaging::{
+    FindWindowW, SW_RESTORE, SetForegroundWindow, ShowWindow,
+};
 use windows::core::w;
 use winit::application::ApplicationHandler;
 use winit::dpi::LogicalSize;
@@ -1577,6 +1580,18 @@ impl ApplicationHandler for SettingsApp {
             if elapsed < target {
                 std::thread::sleep(target - elapsed);
             }
+        }
+    }
+}
+
+pub fn bring_settings_to_front() {
+    unsafe {
+        let hwnd = FindWindowW(None, w!("Settings"));
+        if let Ok(hwnd) = hwnd
+            && !hwnd.is_invalid()
+        {
+            let _ = ShowWindow(hwnd, SW_RESTORE);
+            let _ = SetForegroundWindow(hwnd);
         }
     }
 }

--- a/src/window/settings.rs
+++ b/src/window/settings.rs
@@ -1355,7 +1355,7 @@ impl SettingsApp {
 impl ApplicationHandler for SettingsApp {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         let attrs = Window::default_attributes()
-            .with_title("Settings")
+            .with_title("WinIsland Settings")
             .with_inner_size(LogicalSize::new(WIN_W as f64, WIN_H as f64))
             .with_resizable(false)
             .with_enabled_buttons(WindowButtons::CLOSE | WindowButtons::MINIMIZE)
@@ -1586,7 +1586,7 @@ impl ApplicationHandler for SettingsApp {
 
 pub fn bring_settings_to_front() {
     unsafe {
-        let hwnd = FindWindowW(None, w!("Settings"));
+        let hwnd = FindWindowW(None, w!("WinIsland Settings"));
         if let Ok(hwnd) = hwnd
             && !hwnd.is_invalid()
         {


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `CONTRIBUTING.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## pr方向 (一定要选其中一个)
- [x] `fix` Bug 修复

## 影响范围（可多选）
- [x] 程序核心 Core
    - [x] 功能逻辑 

## 关联 Issue
- Closes #60 

## pr内容

### 摘要
修复了setting能多开的问题

### 动机/背景
#60

### 具体改动
- App 结构体新增 settings_process: RefCell<Option<std::process::Child>> 字段，追踪 settings 子进程
- 新增 open_settings(&self) 方法：先通过 try_wait() 检查之前 spawn 的进程是否还活着
- 还活着 → 调用 bring_settings_to_front() 把已有窗口拉到前台， return
- 已退出 → 重新 spawn 并存下新句柄
- 托盘菜单和齿轮图标两处都改为调用 self.open_settings()
- 添加 bring_settings_to_front() 函数，通过 FindWindowW + ShowWindow + SetForegroundWindow 把已存在的 Settings 窗口拉到前台
- --settings 路径补回互斥体 Local\WinIsland_Settings_Mutex ，防止通过命令行等方式直接多开



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/eatgrapes/winisland/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->