### PR TITLE
fix: resolve multiple crash issues and SMTC session loss

### DIFF
--- a/src/core/persistence.rs
+++ b/src/core/persistence.rs
@@ -24,10 +24,10 @@ pub fn load_config() -> AppConfig {
         return default;
     };
     config.global_scale = config.global_scale.clamp(0.5, 5.0);
-    config.base_width = config.base_width.max(40.0);
-    config.base_height = config.base_height.max(15.0);
-    config.expanded_width = config.expanded_width.max(200.0);
-    config.expanded_height = config.expanded_height.max(100.0);
+    config.base_width = config.base_width.clamp(40.0, 400.0);
+    config.base_height = config.base_height.clamp(15.0, 200.0);
+    config.expanded_width = config.expanded_width.clamp(200.0, 2000.0);
+    config.expanded_height = config.expanded_height.clamp(100.0, 1000.0);
     config
 }
 pub fn save_config(config: &AppConfig) {

--- a/src/core/smtc.rs
+++ b/src/core/smtc.rs
@@ -264,6 +264,9 @@ fn smtc_poll_loop(
         current_allowed_apps = apps;
     }
 
+    let mut last_session_seen = Instant::now();
+    let mut last_was_playing = false;
+
     // Initial update with retries for SMTC timeline readiness.
     // Some music apps (Spotify, Netease) take 1-2s to populate
     // TimelineProperties after session creation, so we retry up
@@ -277,6 +280,8 @@ fn smtc_poll_loop(
             current_lyrics_local_dir.as_deref(),
             &mut current_allowed_apps,
             true,
+            &mut last_session_seen,
+            &mut last_was_playing,
         );
         let info = info_tx.borrow();
         let timeline_ready = info.duration_ms > 0
@@ -440,6 +445,8 @@ fn smtc_poll_loop(
                 current_lyrics_local_dir.as_deref(),
                 &mut current_allowed_apps,
                 true,
+                &mut last_session_seen,
+                &mut last_was_playing,
             );
             last_regular_update = Instant::now();
         }
@@ -459,6 +466,8 @@ fn smtc_poll_loop(
                 current_lyrics_local_dir.as_deref(),
                 &mut current_allowed_apps,
                 do_auto_allow,
+                &mut last_session_seen,
+                &mut last_was_playing,
             );
             last_regular_update = Instant::now();
         }
@@ -467,6 +476,7 @@ fn smtc_poll_loop(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn update_media_info(
     manager: &GlobalSystemMediaTransportControlsSessionManager,
     info_tx: &watch::Sender<MediaInfo>,
@@ -475,19 +485,31 @@ fn update_media_info(
     local_dir: Option<&str>,
     allowed_apps: &mut Vec<String>,
     auto_allow: bool,
+    last_session_seen: &mut Instant,
+    last_was_playing: &mut bool,
 ) {
     if auto_allow {
         *allowed_apps = auto_allow_new_apps(manager, allowed_apps);
     }
 
     if let Some(session) = get_target_session(manager, allowed_apps) {
+        *last_session_seen = Instant::now();
         let _ = fetch_properties(&session, info_tx, lyrics_source, lyrics_fallback, local_dir);
-    } else {
+        *last_was_playing = info_tx.borrow().is_playing;
+    } else if *last_was_playing {
         let info = info_tx.borrow();
         if !info.title.is_empty() {
             drop(info);
             let _ = info_tx.send(MediaInfo::default());
-            log::info!("SMTC: session lost, cleared media info");
+            log::info!("SMTC: app closed while playing, cleared immediately");
+        }
+        *last_was_playing = false;
+    } else if last_session_seen.elapsed() > Duration::from_secs(15) {
+        let info = info_tx.borrow();
+        if !info.title.is_empty() {
+            drop(info);
+            let _ = info_tx.send(MediaInfo::default());
+            log::info!("SMTC: paused session lost for >15s, cleared media info");
         }
     }
 }

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -5,6 +5,8 @@ use std::panic::{self, PanicHookInfo};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::SystemTime;
+use windows::Win32::UI::WindowsAndMessaging::{MESSAGEBOX_STYLE, MessageBoxW};
+use windows::core::PCWSTR;
 
 const LOG_DIR: &str = ".winisland/logs";
 const LOG_FILE: &str = "winisland.log";
@@ -142,11 +144,10 @@ pub fn check_crash_flag() {
 }
 
 fn write_crash_report(panic_info: &PanicHookInfo) {
-    let mut path = log_dir();
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default();
-    path.push(format!("crash-{}.txt", format_timestamp(now.as_secs())));
+    let ts = format_timestamp(now.as_secs());
 
     let msg = panic_info
         .payload()
@@ -175,17 +176,73 @@ Location: {}
 // Logs
 See ~/.winisland/logs/winisland.log for recent activity.
 "#,
-        format_timestamp(now.as_secs()),
-        location,
-        msg,
+        ts, location, msg,
     );
 
-    let _ = fs::write(&path, &report);
-    log::error!("Crash report written to {}", path.display());
+    // Try writing to log directory first
+    let mut path = log_dir();
+    path.push(format!("crash-{}.txt", ts));
+
+    if write_report_to(&path, &report).is_ok() {
+        show_message_box(
+            "WinIsland Crash",
+            "Crash report saved. Logs will be written on next startup.",
+        );
+        return;
+    }
+
+    // Fallback: write to Desktop
+    let msg_text = format!("WinIsland crashed at {}\n\nReason: {}", location, msg);
+    if let Some(desktop) = get_desktop_path() {
+        let mut desktop_path = desktop;
+        desktop_path.push(format!("WinIsland-crash-{}.txt", ts));
+        if write_report_to(&desktop_path, &report).is_ok() {
+            show_message_box(
+                "WinIsland Crash",
+                &format!("Crash report saved to:\n{}", desktop_path.display()),
+            );
+            return;
+        }
+    }
+
+    // Final fallback: show message box with crash info
+    show_message_box("WinIsland Crash", &msg_text);
 
     // Create crash flag for delayed startup next time
     let flag = crash_flag_path();
     let _ = fs::write(&flag, "");
+}
+
+fn show_message_box(title: &str, text: &str) {
+    let title_w: Vec<u16> = title.encode_utf16().chain(std::iter::once(0)).collect();
+    let text_w: Vec<u16> = text.encode_utf16().chain(std::iter::once(0)).collect();
+    unsafe {
+        MessageBoxW(
+            None,
+            PCWSTR(text_w.as_ptr()),
+            PCWSTR(title_w.as_ptr()),
+            MESSAGEBOX_STYLE(0x00000010),
+        );
+    }
+}
+
+fn write_report_to(path: &std::path::Path, report: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut file = fs::File::create(path)?;
+    file.write_all(report.as_bytes())?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn get_desktop_path() -> Option<std::path::PathBuf> {
+    if let Ok(path) = std::env::var("USERPROFILE") {
+        let mut buf = std::path::PathBuf::from(path);
+        buf.push("Desktop");
+        if buf.exists() {
+            return Some(buf);
+        }
+    }
+    None
 }
 
 fn panic_hook(info: &PanicHookInfo) {

--- a/src/utils/physics.rs
+++ b/src/utils/physics.rs
@@ -10,8 +10,18 @@ impl Spring {
         }
     }
     pub fn update_dt(&mut self, target: f32, stiffness: f32, damping: f32, dt: f32) {
+        if !dt.is_finite() || dt <= 0.0 {
+            return;
+        }
         let force = (target - self.value) * stiffness * dt;
         self.velocity = (self.velocity + force) * damping.powf(dt);
         self.value += self.velocity * dt;
+        if !self.value.is_finite() {
+            self.value = target;
+            self.velocity = 0.0;
+        }
+        if !self.velocity.is_finite() {
+            self.velocity = 0.0;
+        }
     }
 }

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -834,7 +834,7 @@ impl App {
                     } else {
                         self.lyric_scroll_offset = 0.0;
                         let min_w = self.config.base_width + 35.0;
-                        natural_w.clamp(min_w, max_w)
+                        natural_w.clamp(min_w.min(max_w), max_w)
                     }
                 } else {
                     let display_text = if !self.current_lyric_text.is_empty() {
@@ -846,7 +846,7 @@ impl App {
                     self.lyric_scroll_offset = 0.0;
                     let min_w = self.config.base_width + 35.0;
                     let w: f32 = 60.0 + text_w;
-                    w.clamp(min_w, 450.0)
+                    w.clamp(min_w.min(450.0), 450.0)
                 }
             } else {
                 self.config.base_width + 35.0

--- a/src/window/settings/input.rs
+++ b/src/window/settings/input.rs
@@ -170,32 +170,36 @@ impl SettingsApp {
                         changed = true;
                     } else if l == tr("base_width") {
                         if is_dec {
-                            self.config.base_width = (self.config.base_width - 5.0).max(40.0);
+                            self.config.base_width =
+                                (self.config.base_width - 5.0).clamp(40.0, 400.0);
                         } else {
-                            self.config.base_width += 5.0;
+                            self.config.base_width = (self.config.base_width + 5.0).min(400.0);
                         }
                         changed = true;
                     } else if l == tr("base_height") {
                         if is_dec {
-                            self.config.base_height = (self.config.base_height - 2.0).max(15.0);
+                            self.config.base_height =
+                                (self.config.base_height - 2.0).clamp(15.0, 200.0);
                         } else {
-                            self.config.base_height += 2.0;
+                            self.config.base_height = (self.config.base_height + 2.0).min(200.0);
                         }
                         changed = true;
                     } else if l == tr("expanded_width") {
                         if is_dec {
                             self.config.expanded_width =
-                                (self.config.expanded_width - 10.0).max(200.0);
+                                (self.config.expanded_width - 10.0).clamp(200.0, 2000.0);
                         } else {
-                            self.config.expanded_width += 10.0;
+                            self.config.expanded_width =
+                                (self.config.expanded_width + 10.0).min(2000.0);
                         }
                         changed = true;
                     } else if l == tr("expanded_height") {
                         if is_dec {
                             self.config.expanded_height =
-                                (self.config.expanded_height - 10.0).max(100.0);
+                                (self.config.expanded_height - 10.0).clamp(100.0, 1000.0);
                         } else {
-                            self.config.expanded_height += 10.0;
+                            self.config.expanded_height =
+                                (self.config.expanded_height + 10.0).min(1000.0);
                         }
                         changed = true;
                     } else if l == tr("position_x_offset") {


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `CONTRIBUTING.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## pr方向

- [x] `fix` Bug 修复

## 影响范围

- [x] 程序核心 Core
    - [x] 功能逻辑
    - [ ] 其他 (请在PR描述中说明)

## 关联 Issue

- Fixes #71
  base_width 无上限导致 clamp panic，修复后不再闪退
- Addresses #68
  通过 Spring NaN/Infinity 守卫缓解渲染管线中的 `FAST_FAIL_FATAL_APP_EXIT`，崩溃日志增加了 MessageBox 兜底便于定位
- Closes #31
   clear SMTC immediately on app close, 15s grace on pause only

---

## pr内容

### 摘要

修复两个崩溃问题和一个 SMTC 体验问题：base_width 无上限导致 clamp panic、渲染管线 NaN 传播、暂停后媒体信息丢失。

### 动机/背景

- **#71**：用户报告将 base_width 调到 465 后程序闪退且无法重启。根因是 settings UI 中的 base_width 没有上限，用户不断点加号可以无限制增长。
- **#68**：用户提供 dump 显示 `FAST_FAIL_FATAL_APP_EXIT`，栈严重损坏。虽然无法单次完全消除，但 Spring 的 NaN/Infinity 守卫可以防止数值爆炸传播到 Skia 渲染层，同时崩溃日志增加了写盘 + MessageBox 兜底确保能抓到根本原因。
- **#31**：部分媒体应用在暂停几秒后会释放 SMTC session，导致不立即显示 "No Music playing"，需要增加缓冲延迟。

### 具体改动

| 文件 | 改动 | 目的 |
|------|------|------|
| `src/window/settings/input.rs` | base_width 上限 400、base_height 上限 200、expanded_width 上限 2000、expanded_height 上限 1000 | **#71 根因 — 防止配置越界** |
| `src/core/persistence.rs` | `max()` → `clamp(下限, 上限)` | **#71 重启兜底 — 已写入文件的越界值也能被修复** |
| `src/window/app.rs` | clamp 中用 `min_w.min(max_w)` 防御性写法 | **#71 最后一道防线 — 即使越界值漏进来也不 panic** |
| `src/utils/physics.rs` | Spring::update_dt 加 `is_finite()` + `dt <= 0` 守卫 | **#68 缓解 — 防止 NaN/Infinity 传播到渲染层** |
| `src/utils/logger.rs` | 废除 `fs::write` + `log::error!`，改用 `File::create` → `write_all` → `sync_all`，写失败时退回 Desktop 路径 + MessageBox 兜底 | **#68 顺带 — 确保每次崩溃都能抓到完整报告** |
| `src/core/smtc.rs` | 新增 `last_session_seen`，session 消失后等 15s 才清空 media info | **SMTC 暂停丢失 — 暂停/切歌时不会闪烁消失** |

### 界面变动
无 UI 改动。