### PR TITLE
feat: add render Content API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .idea/
 /.claude/
 /.planning/
+/.trae/
+/my-winisland-plugin/
 Page/node_modules/
 Page/.vitepress/cache
 Page/package-lock.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5468,7 +5468,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winisland-plugin-api"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "ed25519-dalek",
  "hex",

--- a/crates/winisland-plugin-api/Cargo.toml
+++ b/crates/winisland-plugin-api/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "winisland-plugin-api"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "C ABI types for WinIsland plugin development, with optional build-time packaging and signing tools"
 repository = "https://github.com/Eatgrapes/WinIsland"
+homepage = "https://github.com/Eatgrapes/WinIsland"
 license = "MIT"
 keywords = ["plugin", "dynamic-island", "winisland"]
 categories = ["api-bindings", "development-tools::build-utils"]
+readme = "README.md"
 
 [features]
 default = []

--- a/crates/winisland-plugin-api/Cargo.toml
+++ b/crates/winisland-plugin-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winisland-plugin-api"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "C ABI types for WinIsland plugin development, with optional build-time packaging and signing tools"
 repository = "https://github.com/Eatgrapes/WinIsland"

--- a/crates/winisland-plugin-api/README.md
+++ b/crates/winisland-plugin-api/README.md
@@ -1,0 +1,54 @@
+# winisland-plugin-api
+
+C ABI types and tooling for developing **WinIsland** plugins.
+
+WinIsland is a Dynamic Island emulator for Windows. Plugins are native DLLs that communicate with the host via a C-compatible vtable interface — no serialization, no IPC, straight FFI.
+
+## Usage
+
+```toml
+[dependencies]
+winisland-plugin-api = "0.1"
+```
+
+Then export a `plugin_get_instance` function from your `cdylib`:
+
+```rust
+use winisland_plugin_api::*;
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn plugin_get_instance() -> PluginInstanceC {
+    PluginInstanceC {
+        handle: std::ptr::null_mut(),
+        metadata: PluginMetadataC {
+            id: str_to_fixed("my-plugin"),
+            name: str_to_fixed("My Plugin"),
+            version: str_to_fixed("1.0.0"),
+            author: str_to_fixed("Me"),
+            description: str_to_fixed("Does cool stuff"),
+        },
+        vtable: &VTABLE,
+        plugin_type: PluginType::Content as u32,
+    }
+}
+```
+
+## Plugin Types
+
+| Type | Capability |
+|------|-----------|
+| **Content** | Display text/status on the Dynamic Island |
+| **Theme** | Provide custom colours and animation config |
+| **Shortcut** | Expose keyboard shortcuts / quick actions |
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| *(default)* | Core C ABI types only — zero extra dependencies |
+| `packager` | Build-time packaging, ZIP archiving and Ed25519 signing tools |
+
+## Links
+
+- [GitHub](https://github.com/Eatgrapes/WinIsland)
+- [Plugin Development Guide](https://github.com/Eatgrapes/WinIsland/blob/master/Page/plugin-dev.md)

--- a/crates/winisland-plugin-api/src/lib.rs
+++ b/crates/winisland-plugin-api/src/lib.rs
@@ -78,6 +78,21 @@ impl PluginType {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Priority constants
+// ---------------------------------------------------------------------------
+
+/// Playback — media players, podcasts, videos (lowest).
+pub const PRIORITY_LOW: u32 = 0;
+/// Activity — ongoing short-lived activities like timers, screen recording.
+pub const PRIORITY_MEDIUM: u32 = 1;
+/// Alert — notifications that need immediate attention (highest).
+pub const PRIORITY_HIGH: u32 = 2;
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
 /// The return type for fallible plugin host calls.
 ///
 /// This is a C-compatible equivalent of `Result<(), String>`.
@@ -120,6 +135,10 @@ impl PluginResultC {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
 /// Fill a fixed-size byte buffer with a string, zeroing the rest.
 ///
 /// Useful for initialising `#[repr(C)]` struct fields with a
@@ -137,6 +156,10 @@ pub fn str_to_fixed<const N: usize>(s: &str) -> [u8; N] {
     buf[..len].copy_from_slice(&s.as_bytes()[..len]);
     buf
 }
+
+// ---------------------------------------------------------------------------
+// Core ABI types
+// ---------------------------------------------------------------------------
 
 /// Fixed-width plugin metadata exchanged over FFI.
 ///
@@ -225,6 +248,72 @@ pub struct ShortcutC {
     pub hotkey: [u8; 32],
 }
 
+// ---------------------------------------------------------------------------
+// Context (push-based) types — added in 0.2
+// ---------------------------------------------------------------------------
+
+/// Context data sent by a plugin to display on the Dynamic Island.
+#[repr(C)]
+pub struct ContextDataC {
+    /// Priority: [`PRIORITY_LOW`], [`PRIORITY_MEDIUM`], [`PRIORITY_HIGH`].
+    /// Defaults to `PRIORITY_MEDIUM` when zero.
+    pub priority: u32,
+    /// Title text shown in mini and expanded views. Max 255 bytes + NUL.
+    pub title: [u8; 256],
+    /// Expanded body text. Max 511 bytes + NUL.
+    pub body: [u8; 512],
+    /// How many seconds the expanded view stays open before collapsing.
+    pub duration_sec: u32,
+    /// Whether to show a mini summary after collapsing.
+    pub mini_render: bool,
+    /// Mini summary text (used when `mini_render` is true). Max 127 bytes + NUL.
+    pub mini_text: [u8; 128],
+}
+
+/// Opaque context identifier returned by `send_context`.
+#[repr(C)]
+pub struct ContextIdC {
+    /// Encoded as `"plugin_id:uuid"`. Max 127 bytes + NUL.
+    pub id: [u8; 128],
+}
+
+/// Snapshot of the current host state that a plugin can query.
+#[repr(C)]
+pub struct HostStateC {
+    /// Currently playing media title. Max 255 bytes + NUL.
+    pub media_title: [u8; 256],
+    /// Currently playing media artist. Max 255 bytes + NUL.
+    pub media_artist: [u8; 256],
+    /// Whether media is currently playing.
+    pub is_playing: bool,
+    /// Current theme: `"light"` or `"dark"`. Max 31 bytes + NUL.
+    pub theme: [u8; 32],
+}
+
+/// Host-side API table passed to plugins via [`PluginVTable::set_host_api`].
+///
+/// Plugins store this pointer during `set_host_api` and call through it
+/// whenever they need to interact with the host (push context, close context,
+/// query state). All functions are safe to call from any thread.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct HostApiC {
+    /// Push a new context to the Dynamic Island.
+    ///
+    /// Returns a [`ContextIdC`] that can be used later to close or update.
+    pub send_context: unsafe extern "C" fn(PluginHandle, ContextDataC) -> ContextIdC,
+
+    /// Close a previously sent context by its ID.
+    pub close_context: unsafe extern "C" fn(PluginHandle, *const c_char) -> PluginResultC,
+
+    /// Query the current host state.
+    pub query_host_state: unsafe extern "C" fn(PluginHandle) -> HostStateC,
+}
+
+// ---------------------------------------------------------------------------
+// Plugin vtable
+// ---------------------------------------------------------------------------
+
 /// Virtual function table that every plugin DLL must expose.
 ///
 /// This is the **core of the plugin ABI**: the host calls through these
@@ -294,6 +383,13 @@ pub struct PluginVTable {
     /// Required for [`PluginType::Shortcut`] plugins.
     pub execute_shortcut:
         Option<unsafe extern "C" fn(PluginHandle, id: *const c_char) -> PluginResultC>,
+
+    /// Give the plugin a pointer to the host API table.
+    ///
+    /// Called after `on_load`. The plugin should store this pointer
+    /// and use it to call `send_context`, `close_context`, etc.
+    /// May be `None` for plugins that don't need host interaction.
+    pub set_host_api: Option<unsafe extern "C" fn(PluginHandle, *const HostApiC)>,
 }
 
 /// The complete plugin instance returned by the DLL's entry point.

--- a/src/core/context/mod.rs
+++ b/src/core/context/mod.rs
@@ -1,0 +1,116 @@
+#![allow(dead_code)]
+
+mod types;
+
+pub use types::*;
+
+use std::time::{Duration, Instant};
+
+const MINI_TIMEOUT_SECS: u64 = 30;
+
+/// Mini view 应显示的内容来源
+#[derive(Debug, Clone)]
+pub enum MiniContent {
+    Music,
+    Plugin(Box<PluginContext>),
+}
+
+/// 上下文管理器 —— 调度器和生命周期仲裁
+pub struct ContextManager {
+    plugin_contexts: Vec<PluginContext>,
+    smtc_active: bool,
+    expanded_id: Option<ContextId>,
+}
+
+impl ContextManager {
+    pub fn new() -> Self {
+        Self {
+            plugin_contexts: Vec::new(),
+            smtc_active: false,
+            expanded_id: None,
+        }
+    }
+
+    pub fn set_smtc_active(&mut self, active: bool) {
+        self.smtc_active = active;
+    }
+
+    pub fn smtc_active(&self) -> bool {
+        self.smtc_active
+    }
+
+    pub fn push_context(&mut self, ctx: PluginContext) -> ContextId {
+        let id = ctx.id.clone();
+        if let Some(pos) = self
+            .plugin_contexts
+            .iter()
+            .position(|c| c.id.source == ctx.id.source && c.priority == ctx.priority)
+        {
+            self.plugin_contexts.remove(pos);
+        }
+        self.plugin_contexts.push(ctx);
+        id
+    }
+
+    pub fn close_context(&mut self, id: &ContextId) -> bool {
+        let pos = self.plugin_contexts.iter().position(|c| c.id == *id);
+        if let Some(pos) = pos {
+            self.plugin_contexts.remove(pos);
+            if self.expanded_id.as_ref() == Some(id) {
+                self.expanded_id = None;
+            }
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn current_expanded(&self) -> Option<&PluginContext> {
+        self.expanded_id
+            .as_ref()
+            .and_then(|id| self.plugin_contexts.iter().find(|c| c.id == *id))
+    }
+
+    pub fn set_expanded(&mut self, id: Option<ContextId>) {
+        self.expanded_id = id;
+    }
+
+    /// 返回当前 mini 应显示的内容
+    pub fn current_mini(&self) -> Option<MiniContent> {
+        if let Some(ctx) = self.plugin_contexts.iter().rev().find(|c| c.mini_render) {
+            return Some(MiniContent::Plugin(Box::new(ctx.clone())));
+        }
+        if self.smtc_active {
+            return Some(MiniContent::Music);
+        }
+        None
+    }
+
+    pub fn tick(&mut self) {
+        let now = Instant::now();
+
+        if let Some(exp_id) = &self.expanded_id.clone()
+            && let Some(ctx) = self.plugin_contexts.iter().find(|c| c.id == *exp_id)
+            && let Some(started) = ctx.expanded_started_at
+            && now.duration_since(started) > Duration::from_secs(ctx.duration_sec as u64)
+        {
+            self.expanded_id = None;
+            if let Some(ctx) = self.plugin_contexts.iter_mut().find(|c| c.id == *exp_id) {
+                ctx.collapsed_at = Some(now);
+                ctx.mini_timeout_start = Some(now);
+            }
+        }
+
+        let mut to_remove = Vec::new();
+        for ctx in &self.plugin_contexts {
+            if let Some(timeout_start) = ctx.mini_timeout_start
+                && now.duration_since(timeout_start) > Duration::from_secs(MINI_TIMEOUT_SECS)
+            {
+                to_remove.push(ctx.id.clone());
+            }
+        }
+        for id in to_remove {
+            self.close_context(&id);
+        }
+    }
+}

--- a/src/core/context/types.rs
+++ b/src/core/context/types.rs
@@ -1,0 +1,92 @@
+use std::time::Instant;
+
+fn generate_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{:x}", ts)
+}
+
+/// 上下文优先级
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Priority {
+    /// 媒体播放，后台常驻（SMTC）
+    Low = 0,
+    /// 进行中的短期活动（插件默认）
+    Medium = 1,
+    /// 需要即时注意的通知
+    High = 2,
+}
+
+impl Priority {
+    pub fn from_u32(v: u32) -> Option<Self> {
+        match v {
+            0 => Some(Self::Low),
+            1 => Some(Self::Medium),
+            2 => Some(Self::High),
+            _ => None,
+        }
+    }
+
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+/// 上下文唯一标识
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ContextId {
+    /// "smtc" 或插件 ID
+    pub source: String,
+    /// 随机 UUID
+    pub uuid: String,
+}
+
+impl ContextId {
+    pub fn new(source: &str) -> Self {
+        Self {
+            source: source.to_string(),
+            uuid: generate_id(),
+        }
+    }
+
+    /// 从 "source:uuid" 格式解析
+    pub fn from_encoded(s: &str) -> Option<Self> {
+        let (source, uuid) = s.split_once(':')?;
+        Some(Self {
+            source: source.to_string(),
+            uuid: uuid.to_string(),
+        })
+    }
+
+    /// 编码为 "source:uuid"
+    pub fn encode(&self) -> String {
+        format!("{}:{}", self.source, self.uuid)
+    }
+}
+
+/// 插件或系统发送的上下文
+#[derive(Debug, Clone)]
+pub struct PluginContext {
+    pub id: ContextId,
+    pub priority: Priority,
+    /// 标题（mini 显示，expanded 标题行）
+    pub title: String,
+    /// expanded 正文
+    pub body: String,
+    /// 图标 PNG bytes
+    pub icon: Vec<u8>,
+    /// expanded 停留秒数
+    pub duration_sec: u32,
+    /// 是否在 mini 显示摘要
+    pub mini_render: bool,
+    /// mini 摘要文本（mini_render=true 时有意义）
+    pub mini_text: String,
+    pub created_at: Instant,
+    pub expanded_started_at: Option<Instant>,
+    pub collapsed_at: Option<Instant>,
+    /// 30 秒超时计时起点（collapsed 时设置）
+    pub mini_timeout_start: Option<Instant>,
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod audio;
 pub mod config;
+pub mod context;
 pub mod i18n;
 pub mod lyrics;
 pub mod persistence;

--- a/src/core/render.rs
+++ b/src/core/render.rs
@@ -74,16 +74,13 @@ pub struct StyleParams<'a> {
     pub dt: f32,
 }
 
-pub struct PluginTextParams<'a> {
-    pub title: Option<&'a str>,
-    pub message: Option<&'a str>,
-}
+use crate::core::context::MiniContent;
 
 pub struct DrawIslandParams<'a> {
     pub layout: LayoutParams,
     pub media: MediaParams<'a>,
     pub lyrics: LyricsParams<'a>,
-    pub plugin: PluginTextParams<'a>,
+    pub mini_content: Option<MiniContent>,
     pub window: WindowParams,
     pub style: StyleParams<'a>,
 }
@@ -96,7 +93,7 @@ pub fn draw_island(
         layout,
         media,
         lyrics,
-        plugin,
+        mini_content,
         window,
         style,
     } = params;
@@ -426,369 +423,374 @@ pub fn draw_island(
         canvas.restore();
     }
     if mini_alpha_f > 0.01 && current_w > 45.0 * global_scale {
-        if music_active {
-            let alpha = (mini_alpha_f * 255.0) as u8;
-            if let Some(image) = get_cached_media_image(media) {
-                let base_size = 18.0 * global_scale;
-                let (size, ix, iy) = if mini_cover_shape == "circle" {
-                    let s = base_size * 1.15;
-                    let x = offset_x + 10.0 * global_scale - (s - base_size) / 2.0;
-                    let y = offset_y + (current_h - s) / 2.0;
-                    (s, x, y)
-                } else {
-                    (
-                        base_size,
-                        offset_x + 10.0 * global_scale,
-                        offset_y + (current_h - base_size) / 2.0,
-                    )
-                };
-                let mut paint = Paint::default();
-                paint.set_anti_alias(true);
-                paint.set_alpha_f(alpha as f32 / 255.0);
-                canvas.save();
+        match &mini_content {
+            Some(MiniContent::Music) => {
+                let alpha = (mini_alpha_f * 255.0) as u8;
+                if let Some(image) = get_cached_media_image(media) {
+                    let base_size = 18.0 * global_scale;
+                    let (size, ix, iy) = if mini_cover_shape == "circle" {
+                        let s = base_size * 1.15;
+                        let x = offset_x + 10.0 * global_scale - (s - base_size) / 2.0;
+                        let y = offset_y + (current_h - s) / 2.0;
+                        (s, x, y)
+                    } else {
+                        (
+                            base_size,
+                            offset_x + 10.0 * global_scale,
+                            offset_y + (current_h - base_size) / 2.0,
+                        )
+                    };
+                    let mut paint = Paint::default();
+                    paint.set_anti_alias(true);
+                    paint.set_alpha_f(alpha as f32 / 255.0);
+                    canvas.save();
 
-                let is_mini_rotating =
-                    cover_rotate && mini_cover_shape == "circle" && media.is_playing;
-                let mini_rotation_angle = MINI_COVER_ROTATION.with(|cell| {
-                    let mut angle = cell.borrow_mut();
-                    if is_mini_rotating {
-                        *angle += 0.5 * dt;
-                        if *angle >= 360.0 {
-                            *angle -= 360.0;
+                    let is_mini_rotating =
+                        cover_rotate && mini_cover_shape == "circle" && media.is_playing;
+                    let mini_rotation_angle = MINI_COVER_ROTATION.with(|cell| {
+                        let mut angle = cell.borrow_mut();
+                        if is_mini_rotating {
+                            *angle += 0.5 * dt;
+                            if *angle >= 360.0 {
+                                *angle -= 360.0;
+                            }
                         }
+                        *angle
+                    });
+
+                    if cover_rotate && mini_cover_shape == "circle" {
+                        let img_cx = ix + size / 2.0;
+                        let img_cy = iy + size / 2.0;
+                        canvas.translate((img_cx, img_cy));
+                        canvas.rotate(mini_rotation_angle, None);
+                        canvas.translate((-img_cx, -img_cy));
                     }
-                    *angle
+
+                    if mini_cover_shape == "circle" {
+                        canvas.clip_rrect(
+                            RRect::new_rect_xy(
+                                Rect::from_xywh(ix, iy, size, size),
+                                size / 2.0,
+                                size / 2.0,
+                            ),
+                            ClipOp::Intersect,
+                            true,
+                        );
+                    } else {
+                        canvas.clip_rrect(
+                            RRect::new_rect_xy(
+                                Rect::from_xywh(ix, iy, size, size),
+                                5.0 * global_scale,
+                                5.0 * global_scale,
+                            ),
+                            ClipOp::Intersect,
+                            true,
+                        );
+                    }
+                    let sampling = SamplingOptions::new(FilterMode::Linear, MipmapMode::Linear);
+                    let img_w = image.width() as f32;
+                    let img_h = image.height() as f32;
+                    let src_rect = if img_w > 0.0 && img_h > 0.0 {
+                        let aspect = img_w / img_h;
+                        let src = if aspect > 1.0 {
+                            let crop_w = img_h;
+                            let offset_x = (img_w - crop_w) / 2.0;
+                            Rect::from_xywh(offset_x, 0.0, crop_w, img_h)
+                        } else {
+                            let crop_h = img_w;
+                            let offset_y = (img_h - crop_h) / 2.0;
+                            Rect::from_xywh(0.0, offset_y, img_w, crop_h)
+                        };
+                        Some(src)
+                    } else {
+                        None
+                    };
+                    canvas.draw_image_rect_with_sampling_options(
+                        &image,
+                        src_rect.as_ref().map(|r| (r, SrcRectConstraint::Fast)),
+                        Rect::from_xywh(ix, iy, size, size),
+                        sampling,
+                        &paint,
+                    );
+                    canvas.restore();
+
+                    if is_mini_rotating {
+                        widget_animating = true;
+                    }
+                }
+                let palette = &palette;
+                let viz_x = offset_x + current_w - 17.0 * global_scale;
+                let viz_y = offset_y + current_h / 2.0;
+                draw_visualizer(DrawVisualizerParams {
+                    canvas,
+                    x: viz_x,
+                    y: viz_y,
+                    alpha,
+                    is_playing: media.is_playing,
+                    palette,
+                    spectrum: &media.spectrum,
+                    w_scale: 0.55 * global_scale,
+                    h_scale: viz_h_scale * global_scale,
+                    smooth_factors: (0.6, 0.08),
                 });
 
-                if cover_rotate && mini_cover_shape == "circle" {
-                    let img_cx = ix + size / 2.0;
-                    let img_cy = iy + size / 2.0;
-                    canvas.translate((img_cx, img_cy));
-                    canvas.rotate(mini_rotation_angle, None);
-                    canvas.translate((-img_cx, -img_cy));
-                }
+                let is_paused = music_active && !media.is_playing && style.mini_controls;
 
-                if mini_cover_shape == "circle" {
-                    canvas.clip_rrect(
-                        RRect::new_rect_xy(
-                            Rect::from_xywh(ix, iy, size, size),
-                            size / 2.0,
-                            size / 2.0,
-                        ),
-                        ClipOp::Intersect,
-                        true,
-                    );
-                } else {
-                    canvas.clip_rrect(
-                        RRect::new_rect_xy(
-                            Rect::from_xywh(ix, iy, size, size),
-                            5.0 * global_scale,
-                            5.0 * global_scale,
-                        ),
-                        ClipOp::Intersect,
-                        true,
-                    );
-                }
-                let sampling = SamplingOptions::new(FilterMode::Linear, MipmapMode::Linear);
-                let img_w = image.width() as f32;
-                let img_h = image.height() as f32;
-                let src_rect = if img_w > 0.0 && img_h > 0.0 {
-                    let aspect = img_w / img_h;
-                    let src = if aspect > 1.0 {
-                        let crop_w = img_h;
-                        let offset_x = (img_w - crop_w) / 2.0;
-                        Rect::from_xywh(offset_x, 0.0, crop_w, img_h)
-                    } else {
-                        let crop_h = img_w;
-                        let offset_y = (img_h - crop_h) / 2.0;
-                        Rect::from_xywh(0.0, offset_y, img_w, crop_h)
-                    };
-                    Some(src)
-                } else {
-                    None
-                };
-                canvas.draw_image_rect_with_sampling_options(
-                    &image,
-                    src_rect.as_ref().map(|r| (r, SrcRectConstraint::Fast)),
-                    Rect::from_xywh(ix, iy, size, size),
-                    sampling,
-                    &paint,
-                );
-                canvas.restore();
+                if is_paused {
+                    let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
+                    let ctrl_alpha = (alpha as f32 * lyric_fade_f) as u8;
 
-                if is_mini_rotating {
-                    widget_animating = true;
-                }
-            }
-            let palette = &palette;
-            let viz_x = offset_x + current_w - 17.0 * global_scale;
-            let viz_y = offset_y + current_h / 2.0;
-            draw_visualizer(DrawVisualizerParams {
-                canvas,
-                x: viz_x,
-                y: viz_y,
-                alpha,
-                is_playing: media.is_playing,
-                palette,
-                spectrum: &media.spectrum,
-                w_scale: 0.55 * global_scale,
-                h_scale: viz_h_scale * global_scale,
-                smooth_factors: (0.6, 0.08),
-            });
+                    if ctrl_alpha > 0 {
+                        let space_left = offset_x + 30.0 * global_scale;
+                        let space_right = offset_x + current_w - 29.0 * global_scale;
+                        let center_x = (space_left + space_right) / 2.0;
+                        let center_y = offset_y + current_h / 2.0;
 
-            let is_paused = music_active && !media.is_playing && style.mini_controls;
+                        let btn_scale = 0.28 * global_scale;
 
-            if is_paused {
-                let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
-                let ctrl_alpha = (alpha as f32 * lyric_fade_f) as u8;
-
-                if ctrl_alpha > 0 {
-                    let space_left = offset_x + 30.0 * global_scale;
-                    let space_right = offset_x + current_w - 29.0 * global_scale;
-                    let center_x = (space_left + space_right) / 2.0;
-                    let center_y = offset_y + current_h / 2.0;
-
-                    let btn_scale = 0.28 * global_scale;
-
-                    canvas.save();
-                    canvas.translate((center_x, center_y));
-                    draw_play_button(canvas, 0.0, 0.0, ctrl_alpha, btn_scale, text_color);
-                    canvas.restore();
-                }
-            } else if !current_lyric.is_empty() || !old_lyric.is_empty() {
-                let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
-                let alpha = (alpha as f32 * lyric_fade_f) as u8;
-
-                if alpha > 0 {
-                    let lyric_font_sz = if font_size > 0.0 {
-                        font_size * 0.8 * global_scale
-                    } else {
-                        12.0 * global_scale
-                    };
-                    let space_left = offset_x + 30.0 * global_scale;
-                    let space_right = offset_x + current_w - 29.0 * global_scale;
-                    let available_w = space_right - space_left;
-                    let scrolling = lyric_scroll_offset > 0.0;
-                    let text_x = if scrolling {
-                        space_left - lyric_scroll_offset
-                    } else {
-                        space_left + available_w / 2.0
-                    };
-                    let text_centered = !scrolling;
-
-                    canvas.save();
-                    let clip_rect = Rect::from_xywh(space_left, offset_y, available_w, current_h);
-                    canvas.clip_rect(clip_rect, ClipOp::Intersect, true);
-
-                    if use_blur {
-                        if lyric_transition < 1.0 && !old_lyric.is_empty() {
-                            let mut text_paint = Paint::default();
-                            text_paint.set_anti_alias(true);
-                            let fade_alpha = (alpha as f32 * (1.0 - lyric_transition)) as u8;
-                            text_paint.set_color(Color::from_argb(
-                                fade_alpha,
-                                text_color.r(),
-                                text_color.g(),
-                                text_color.b(),
-                            ));
-
-                            let blur_sigma = lyric_transition * 12.0 * global_scale;
-                            if blur_sigma > 0.1 {
-                                text_paint.set_image_filter(image_filters::blur(
-                                    (blur_sigma, 0.0),
-                                    None,
-                                    None,
-                                    None,
-                                ));
-                            }
-
-                            let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale
-                                - (10.0 * global_scale * lyric_transition);
-                            let old_lx = if text_centered {
-                                let w = FontManager::global().measure_text_cached(
-                                    old_lyric,
-                                    lyric_font_sz,
-                                    skia_safe::FontStyle::normal(),
-                                );
-                                text_x - w / 2.0
-                            } else {
-                                text_x
-                            };
-                            draw_text_cached(DrawTextCachedParams {
-                                canvas,
-                                text: old_lyric,
-                                x: old_lx,
-                                y: text_y,
-                                size: lyric_font_sz,
-                                bold: false,
-                                paint: &text_paint,
-                            });
-                        }
-
-                        if !current_lyric.is_empty() {
-                            let mut text_paint = Paint::default();
-                            text_paint.set_anti_alias(true);
-                            let fade_alpha = (alpha as f32 * lyric_transition) as u8;
-                            text_paint.set_color(Color::from_argb(
-                                fade_alpha,
-                                text_color.r(),
-                                text_color.g(),
-                                text_color.b(),
-                            ));
-
-                            let blur_sigma = (1.0 - lyric_transition) * 12.0 * global_scale;
-                            if blur_sigma > 0.1 {
-                                text_paint.set_image_filter(image_filters::blur(
-                                    (blur_sigma, 0.0),
-                                    None,
-                                    None,
-                                    None,
-                                ));
-                            }
-
-                            let text_y = offset_y
-                                + current_h / 2.0
-                                + 4.0 * global_scale
-                                + (10.0 * global_scale * (1.0 - lyric_transition));
-                            let cur_lx = if text_centered {
-                                let w = FontManager::global().measure_text_cached(
-                                    current_lyric,
-                                    lyric_font_sz,
-                                    skia_safe::FontStyle::normal(),
-                                );
-                                text_x - w / 2.0
-                            } else {
-                                text_x
-                            };
-                            draw_text_cached(DrawTextCachedParams {
-                                canvas,
-                                text: current_lyric,
-                                x: cur_lx,
-                                y: text_y,
-                                size: lyric_font_sz,
-                                bold: false,
-                                paint: &text_paint,
-                            });
-                        }
-                    } else {
-                        let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale;
-                        if lyric_transition < 0.5 && !old_lyric.is_empty() {
-                            let mut text_paint = Paint::default();
-                            text_paint.set_anti_alias(true);
-                            let progress = lyric_transition * 2.0;
-                            let fade_alpha = (alpha as f32 * (1.0 - progress)) as u8;
-                            text_paint.set_color(Color::from_argb(
-                                fade_alpha,
-                                text_color.r(),
-                                text_color.g(),
-                                text_color.b(),
-                            ));
-                            let old_lx2 = if text_centered {
-                                let w = FontManager::global().measure_text_cached(
-                                    old_lyric,
-                                    lyric_font_sz,
-                                    skia_safe::FontStyle::normal(),
-                                );
-                                text_x - w / 2.0
-                            } else {
-                                text_x
-                            };
-                            draw_text_cached(DrawTextCachedParams {
-                                canvas,
-                                text: old_lyric,
-                                x: old_lx2,
-                                y: text_y,
-                                size: lyric_font_sz,
-                                bold: false,
-                                paint: &text_paint,
-                            });
-                        } else if lyric_transition >= 0.5 && !current_lyric.is_empty() {
-                            let mut text_paint = Paint::default();
-                            text_paint.set_anti_alias(true);
-                            let progress = (lyric_transition - 0.5) * 2.0;
-                            let fade_alpha = (alpha as f32 * progress) as u8;
-                            text_paint.set_color(Color::from_argb(
-                                fade_alpha,
-                                text_color.r(),
-                                text_color.g(),
-                                text_color.b(),
-                            ));
-                            let cur_lx2 = if text_centered {
-                                let w = FontManager::global().measure_text_cached(
-                                    current_lyric,
-                                    lyric_font_sz,
-                                    skia_safe::FontStyle::normal(),
-                                );
-                                text_x - w / 2.0
-                            } else {
-                                text_x
-                            };
-                            draw_text_cached(DrawTextCachedParams {
-                                canvas,
-                                text: current_lyric,
-                                x: cur_lx2,
-                                y: text_y,
-                                size: lyric_font_sz,
-                                bold: false,
-                                paint: &text_paint,
-                            });
-                        }
+                        canvas.save();
+                        canvas.translate((center_x, center_y));
+                        draw_play_button(canvas, 0.0, 0.0, ctrl_alpha, btn_scale, text_color);
+                        canvas.restore();
                     }
-                    canvas.restore();
+                } else if !current_lyric.is_empty() || !old_lyric.is_empty() {
+                    let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
+                    let alpha = (alpha as f32 * lyric_fade_f) as u8;
+
+                    if alpha > 0 {
+                        let lyric_font_sz = if font_size > 0.0 {
+                            font_size * 0.8 * global_scale
+                        } else {
+                            12.0 * global_scale
+                        };
+                        let space_left = offset_x + 30.0 * global_scale;
+                        let space_right = offset_x + current_w - 29.0 * global_scale;
+                        let available_w = space_right - space_left;
+                        let scrolling = lyric_scroll_offset > 0.0;
+                        let text_x = if scrolling {
+                            space_left - lyric_scroll_offset
+                        } else {
+                            space_left + available_w / 2.0
+                        };
+                        let text_centered = !scrolling;
+
+                        canvas.save();
+                        let clip_rect =
+                            Rect::from_xywh(space_left, offset_y, available_w, current_h);
+                        canvas.clip_rect(clip_rect, ClipOp::Intersect, true);
+
+                        if use_blur {
+                            if lyric_transition < 1.0 && !old_lyric.is_empty() {
+                                let mut text_paint = Paint::default();
+                                text_paint.set_anti_alias(true);
+                                let fade_alpha = (alpha as f32 * (1.0 - lyric_transition)) as u8;
+                                text_paint.set_color(Color::from_argb(
+                                    fade_alpha,
+                                    text_color.r(),
+                                    text_color.g(),
+                                    text_color.b(),
+                                ));
+
+                                let blur_sigma = lyric_transition * 12.0 * global_scale;
+                                if blur_sigma > 0.1 {
+                                    text_paint.set_image_filter(image_filters::blur(
+                                        (blur_sigma, 0.0),
+                                        None,
+                                        None,
+                                        None,
+                                    ));
+                                }
+
+                                let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale
+                                    - (10.0 * global_scale * lyric_transition);
+                                let old_lx = if text_centered {
+                                    let w = FontManager::global().measure_text_cached(
+                                        old_lyric,
+                                        lyric_font_sz,
+                                        skia_safe::FontStyle::normal(),
+                                    );
+                                    text_x - w / 2.0
+                                } else {
+                                    text_x
+                                };
+                                draw_text_cached(DrawTextCachedParams {
+                                    canvas,
+                                    text: old_lyric,
+                                    x: old_lx,
+                                    y: text_y,
+                                    size: lyric_font_sz,
+                                    bold: false,
+                                    paint: &text_paint,
+                                });
+                            }
+
+                            if !current_lyric.is_empty() {
+                                let mut text_paint = Paint::default();
+                                text_paint.set_anti_alias(true);
+                                let fade_alpha = (alpha as f32 * lyric_transition) as u8;
+                                text_paint.set_color(Color::from_argb(
+                                    fade_alpha,
+                                    text_color.r(),
+                                    text_color.g(),
+                                    text_color.b(),
+                                ));
+
+                                let blur_sigma = (1.0 - lyric_transition) * 12.0 * global_scale;
+                                if blur_sigma > 0.1 {
+                                    text_paint.set_image_filter(image_filters::blur(
+                                        (blur_sigma, 0.0),
+                                        None,
+                                        None,
+                                        None,
+                                    ));
+                                }
+
+                                let text_y = offset_y
+                                    + current_h / 2.0
+                                    + 4.0 * global_scale
+                                    + (10.0 * global_scale * (1.0 - lyric_transition));
+                                let cur_lx = if text_centered {
+                                    let w = FontManager::global().measure_text_cached(
+                                        current_lyric,
+                                        lyric_font_sz,
+                                        skia_safe::FontStyle::normal(),
+                                    );
+                                    text_x - w / 2.0
+                                } else {
+                                    text_x
+                                };
+                                draw_text_cached(DrawTextCachedParams {
+                                    canvas,
+                                    text: current_lyric,
+                                    x: cur_lx,
+                                    y: text_y,
+                                    size: lyric_font_sz,
+                                    bold: false,
+                                    paint: &text_paint,
+                                });
+                            }
+                        } else {
+                            let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale;
+                            if lyric_transition < 0.5 && !old_lyric.is_empty() {
+                                let mut text_paint = Paint::default();
+                                text_paint.set_anti_alias(true);
+                                let progress = lyric_transition * 2.0;
+                                let fade_alpha = (alpha as f32 * (1.0 - progress)) as u8;
+                                text_paint.set_color(Color::from_argb(
+                                    fade_alpha,
+                                    text_color.r(),
+                                    text_color.g(),
+                                    text_color.b(),
+                                ));
+                                let old_lx2 = if text_centered {
+                                    let w = FontManager::global().measure_text_cached(
+                                        old_lyric,
+                                        lyric_font_sz,
+                                        skia_safe::FontStyle::normal(),
+                                    );
+                                    text_x - w / 2.0
+                                } else {
+                                    text_x
+                                };
+                                draw_text_cached(DrawTextCachedParams {
+                                    canvas,
+                                    text: old_lyric,
+                                    x: old_lx2,
+                                    y: text_y,
+                                    size: lyric_font_sz,
+                                    bold: false,
+                                    paint: &text_paint,
+                                });
+                            } else if lyric_transition >= 0.5 && !current_lyric.is_empty() {
+                                let mut text_paint = Paint::default();
+                                text_paint.set_anti_alias(true);
+                                let progress = (lyric_transition - 0.5) * 2.0;
+                                let fade_alpha = (alpha as f32 * progress) as u8;
+                                text_paint.set_color(Color::from_argb(
+                                    fade_alpha,
+                                    text_color.r(),
+                                    text_color.g(),
+                                    text_color.b(),
+                                ));
+                                let cur_lx2 = if text_centered {
+                                    let w = FontManager::global().measure_text_cached(
+                                        current_lyric,
+                                        lyric_font_sz,
+                                        skia_safe::FontStyle::normal(),
+                                    );
+                                    text_x - w / 2.0
+                                } else {
+                                    text_x
+                                };
+                                draw_text_cached(DrawTextCachedParams {
+                                    canvas,
+                                    text: current_lyric,
+                                    x: cur_lx2,
+                                    y: text_y,
+                                    size: lyric_font_sz,
+                                    bold: false,
+                                    paint: &text_paint,
+                                });
+                            }
+                        }
+                        canvas.restore();
+                    }
                 }
             }
-        } else if let Some(plugin_text) = plugin.title {
-            let font_sz = if font_size > 0.0 {
-                font_size * 0.7 * global_scale
-            } else {
-                11.0 * global_scale
-            };
-            let alpha = (mini_alpha_f * 255.0) as u8;
-            let mut text_paint = Paint::default();
-            text_paint.set_anti_alias(true);
-            text_paint.set_color(Color::from_argb(
-                alpha,
-                text_color.r(),
-                text_color.g(),
-                text_color.b(),
-            ));
-            let text_x = offset_x + 20.0 * global_scale;
-            let text_w = current_w - 40.0 * global_scale;
-            let text_y = offset_y + current_h / 2.0 - font_sz * 0.3;
-            canvas.save();
-            let clip = Rect::from_xywh(text_x, offset_y, text_w, current_h);
-            canvas.clip_rect(clip, ClipOp::Intersect, true);
-            draw_text_cached(DrawTextCachedParams {
-                canvas,
-                text: plugin_text,
-                x: text_x,
-                y: text_y,
-                size: font_sz,
-                bold: true,
-                paint: &text_paint,
-            });
-            if let Some(msg) = plugin.message {
-                let sec_font_sz = font_sz * 0.8;
-                let mut sec_paint = Paint::default();
-                sec_paint.set_anti_alias(true);
-                sec_paint.set_color(Color::from_argb(
-                    (alpha as f32 * 0.7) as u8,
+            Some(MiniContent::Plugin(ctx)) => {
+                let font_sz = if font_size > 0.0 {
+                    font_size * 0.7 * global_scale
+                } else {
+                    11.0 * global_scale
+                };
+                let alpha = (mini_alpha_f * 255.0) as u8;
+                let mut text_paint = Paint::default();
+                text_paint.set_anti_alias(true);
+                text_paint.set_color(Color::from_argb(
+                    alpha,
                     text_color.r(),
                     text_color.g(),
                     text_color.b(),
                 ));
-                let sec_y = text_y + font_sz * 1.3;
+                let text_x = offset_x + 20.0 * global_scale;
+                let text_w = current_w - 40.0 * global_scale;
+                let text_y = offset_y + current_h / 2.0 - font_sz * 0.3;
+                canvas.save();
+                let clip = Rect::from_xywh(text_x, offset_y, text_w, current_h);
+                canvas.clip_rect(clip, ClipOp::Intersect, true);
                 draw_text_cached(DrawTextCachedParams {
                     canvas,
-                    text: msg,
+                    text: &ctx.title,
                     x: text_x,
-                    y: sec_y,
-                    size: sec_font_sz,
-                    bold: false,
-                    paint: &sec_paint,
+                    y: text_y,
+                    size: font_sz,
+                    bold: true,
+                    paint: &text_paint,
                 });
+                if !ctx.body.is_empty() {
+                    let sec_font_sz = font_sz * 0.8;
+                    let mut sec_paint = Paint::default();
+                    sec_paint.set_anti_alias(true);
+                    sec_paint.set_color(Color::from_argb(
+                        (alpha as f32 * 0.7) as u8,
+                        text_color.r(),
+                        text_color.g(),
+                        text_color.b(),
+                    ));
+                    let sec_y = text_y + font_sz * 1.3;
+                    draw_text_cached(DrawTextCachedParams {
+                        canvas,
+                        text: &ctx.body,
+                        x: text_x,
+                        y: sec_y,
+                        size: sec_font_sz,
+                        bold: false,
+                        paint: &sec_paint,
+                    });
+                }
+                canvas.restore();
             }
-            canvas.restore();
+            None => {}
         }
     }
     canvas.restore();

--- a/src/core/render.rs
+++ b/src/core/render.rs
@@ -74,10 +74,16 @@ pub struct StyleParams<'a> {
     pub dt: f32,
 }
 
+pub struct PluginTextParams<'a> {
+    pub title: Option<&'a str>,
+    pub message: Option<&'a str>,
+}
+
 pub struct DrawIslandParams<'a> {
     pub layout: LayoutParams,
     pub media: MediaParams<'a>,
     pub lyrics: LyricsParams<'a>,
+    pub plugin: PluginTextParams<'a>,
     pub window: WindowParams,
     pub style: StyleParams<'a>,
 }
@@ -90,6 +96,7 @@ pub fn draw_island(
         layout,
         media,
         lyrics,
+        plugin,
         window,
         style,
     } = params;
@@ -418,311 +425,370 @@ pub fn draw_island(
         }
         canvas.restore();
     }
-    if mini_alpha_f > 0.01 && current_w > 45.0 * global_scale && music_active {
-        let alpha = (mini_alpha_f * 255.0) as u8;
-        if let Some(image) = get_cached_media_image(media) {
-            let base_size = 18.0 * global_scale;
-            let (size, ix, iy) = if mini_cover_shape == "circle" {
-                let s = base_size * 1.15;
-                let x = offset_x + 10.0 * global_scale - (s - base_size) / 2.0;
-                let y = offset_y + (current_h - s) / 2.0;
-                (s, x, y)
-            } else {
-                (
-                    base_size,
-                    offset_x + 10.0 * global_scale,
-                    offset_y + (current_h - base_size) / 2.0,
-                )
-            };
-            let mut paint = Paint::default();
-            paint.set_anti_alias(true);
-            paint.set_alpha_f(alpha as f32 / 255.0);
-            canvas.save();
+    if mini_alpha_f > 0.01 && current_w > 45.0 * global_scale {
+        if music_active {
+            let alpha = (mini_alpha_f * 255.0) as u8;
+            if let Some(image) = get_cached_media_image(media) {
+                let base_size = 18.0 * global_scale;
+                let (size, ix, iy) = if mini_cover_shape == "circle" {
+                    let s = base_size * 1.15;
+                    let x = offset_x + 10.0 * global_scale - (s - base_size) / 2.0;
+                    let y = offset_y + (current_h - s) / 2.0;
+                    (s, x, y)
+                } else {
+                    (
+                        base_size,
+                        offset_x + 10.0 * global_scale,
+                        offset_y + (current_h - base_size) / 2.0,
+                    )
+                };
+                let mut paint = Paint::default();
+                paint.set_anti_alias(true);
+                paint.set_alpha_f(alpha as f32 / 255.0);
+                canvas.save();
 
-            let is_mini_rotating = cover_rotate && mini_cover_shape == "circle" && media.is_playing;
-            let mini_rotation_angle = MINI_COVER_ROTATION.with(|cell| {
-                let mut angle = cell.borrow_mut();
-                if is_mini_rotating {
-                    *angle += 0.5 * dt;
-                    if *angle >= 360.0 {
-                        *angle -= 360.0;
+                let is_mini_rotating =
+                    cover_rotate && mini_cover_shape == "circle" && media.is_playing;
+                let mini_rotation_angle = MINI_COVER_ROTATION.with(|cell| {
+                    let mut angle = cell.borrow_mut();
+                    if is_mini_rotating {
+                        *angle += 0.5 * dt;
+                        if *angle >= 360.0 {
+                            *angle -= 360.0;
+                        }
                     }
+                    *angle
+                });
+
+                if cover_rotate && mini_cover_shape == "circle" {
+                    let img_cx = ix + size / 2.0;
+                    let img_cy = iy + size / 2.0;
+                    canvas.translate((img_cx, img_cy));
+                    canvas.rotate(mini_rotation_angle, None);
+                    canvas.translate((-img_cx, -img_cy));
                 }
-                *angle
+
+                if mini_cover_shape == "circle" {
+                    canvas.clip_rrect(
+                        RRect::new_rect_xy(
+                            Rect::from_xywh(ix, iy, size, size),
+                            size / 2.0,
+                            size / 2.0,
+                        ),
+                        ClipOp::Intersect,
+                        true,
+                    );
+                } else {
+                    canvas.clip_rrect(
+                        RRect::new_rect_xy(
+                            Rect::from_xywh(ix, iy, size, size),
+                            5.0 * global_scale,
+                            5.0 * global_scale,
+                        ),
+                        ClipOp::Intersect,
+                        true,
+                    );
+                }
+                let sampling = SamplingOptions::new(FilterMode::Linear, MipmapMode::Linear);
+                let img_w = image.width() as f32;
+                let img_h = image.height() as f32;
+                let src_rect = if img_w > 0.0 && img_h > 0.0 {
+                    let aspect = img_w / img_h;
+                    let src = if aspect > 1.0 {
+                        let crop_w = img_h;
+                        let offset_x = (img_w - crop_w) / 2.0;
+                        Rect::from_xywh(offset_x, 0.0, crop_w, img_h)
+                    } else {
+                        let crop_h = img_w;
+                        let offset_y = (img_h - crop_h) / 2.0;
+                        Rect::from_xywh(0.0, offset_y, img_w, crop_h)
+                    };
+                    Some(src)
+                } else {
+                    None
+                };
+                canvas.draw_image_rect_with_sampling_options(
+                    &image,
+                    src_rect.as_ref().map(|r| (r, SrcRectConstraint::Fast)),
+                    Rect::from_xywh(ix, iy, size, size),
+                    sampling,
+                    &paint,
+                );
+                canvas.restore();
+
+                if is_mini_rotating {
+                    widget_animating = true;
+                }
+            }
+            let palette = &palette;
+            let viz_x = offset_x + current_w - 17.0 * global_scale;
+            let viz_y = offset_y + current_h / 2.0;
+            draw_visualizer(DrawVisualizerParams {
+                canvas,
+                x: viz_x,
+                y: viz_y,
+                alpha,
+                is_playing: media.is_playing,
+                palette,
+                spectrum: &media.spectrum,
+                w_scale: 0.55 * global_scale,
+                h_scale: viz_h_scale * global_scale,
+                smooth_factors: (0.6, 0.08),
             });
 
-            if cover_rotate && mini_cover_shape == "circle" {
-                let img_cx = ix + size / 2.0;
-                let img_cy = iy + size / 2.0;
-                canvas.translate((img_cx, img_cy));
-                canvas.rotate(mini_rotation_angle, None);
-                canvas.translate((-img_cx, -img_cy));
-            }
+            let is_paused = music_active && !media.is_playing && style.mini_controls;
 
-            if mini_cover_shape == "circle" {
-                canvas.clip_rrect(
-                    RRect::new_rect_xy(Rect::from_xywh(ix, iy, size, size), size / 2.0, size / 2.0),
-                    ClipOp::Intersect,
-                    true,
-                );
-            } else {
-                canvas.clip_rrect(
-                    RRect::new_rect_xy(
-                        Rect::from_xywh(ix, iy, size, size),
-                        5.0 * global_scale,
-                        5.0 * global_scale,
-                    ),
-                    ClipOp::Intersect,
-                    true,
-                );
-            }
-            let sampling = SamplingOptions::new(FilterMode::Linear, MipmapMode::Linear);
-            let img_w = image.width() as f32;
-            let img_h = image.height() as f32;
-            let src_rect = if img_w > 0.0 && img_h > 0.0 {
-                let aspect = img_w / img_h;
-                let src = if aspect > 1.0 {
-                    let crop_w = img_h;
-                    let offset_x = (img_w - crop_w) / 2.0;
-                    Rect::from_xywh(offset_x, 0.0, crop_w, img_h)
-                } else {
-                    let crop_h = img_w;
-                    let offset_y = (img_h - crop_h) / 2.0;
-                    Rect::from_xywh(0.0, offset_y, img_w, crop_h)
-                };
-                Some(src)
-            } else {
-                None
-            };
-            canvas.draw_image_rect_with_sampling_options(
-                &image,
-                src_rect.as_ref().map(|r| (r, SrcRectConstraint::Fast)),
-                Rect::from_xywh(ix, iy, size, size),
-                sampling,
-                &paint,
-            );
-            canvas.restore();
+            if is_paused {
+                let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
+                let ctrl_alpha = (alpha as f32 * lyric_fade_f) as u8;
 
-            if is_mini_rotating {
-                widget_animating = true;
-            }
-        }
-        let palette = &palette;
-        let viz_x = offset_x + current_w - 17.0 * global_scale;
-        let viz_y = offset_y + current_h / 2.0;
-        draw_visualizer(DrawVisualizerParams {
-            canvas,
-            x: viz_x,
-            y: viz_y,
-            alpha,
-            is_playing: media.is_playing,
-            palette,
-            spectrum: &media.spectrum,
-            w_scale: 0.55 * global_scale,
-            h_scale: viz_h_scale * global_scale,
-            smooth_factors: (0.6, 0.08),
-        });
+                if ctrl_alpha > 0 {
+                    let space_left = offset_x + 30.0 * global_scale;
+                    let space_right = offset_x + current_w - 29.0 * global_scale;
+                    let center_x = (space_left + space_right) / 2.0;
+                    let center_y = offset_y + current_h / 2.0;
 
-        let is_paused = music_active && !media.is_playing && style.mini_controls;
+                    let btn_scale = 0.28 * global_scale;
 
-        if is_paused {
-            let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
-            let ctrl_alpha = (alpha as f32 * lyric_fade_f) as u8;
-
-            if ctrl_alpha > 0 {
-                let space_left = offset_x + 30.0 * global_scale;
-                let space_right = offset_x + current_w - 29.0 * global_scale;
-                let center_x = (space_left + space_right) / 2.0;
-                let center_y = offset_y + current_h / 2.0;
-
-                let btn_scale = 0.28 * global_scale;
-
-                canvas.save();
-                canvas.translate((center_x, center_y));
-                draw_play_button(canvas, 0.0, 0.0, ctrl_alpha, btn_scale, text_color);
-                canvas.restore();
-            }
-        } else if !current_lyric.is_empty() || !old_lyric.is_empty() {
-            let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
-            let alpha = (alpha as f32 * lyric_fade_f) as u8;
-
-            if alpha > 0 {
-                let lyric_font_sz = if font_size > 0.0 {
-                    font_size * 0.8 * global_scale
-                } else {
-                    12.0 * global_scale
-                };
-                let space_left = offset_x + 30.0 * global_scale;
-                let space_right = offset_x + current_w - 29.0 * global_scale;
-                let available_w = space_right - space_left;
-                let scrolling = lyric_scroll_offset > 0.0;
-                let text_x = if scrolling {
-                    space_left - lyric_scroll_offset
-                } else {
-                    space_left + available_w / 2.0
-                };
-                let text_centered = !scrolling;
-
-                canvas.save();
-                let clip_rect = Rect::from_xywh(space_left, offset_y, available_w, current_h);
-                canvas.clip_rect(clip_rect, ClipOp::Intersect, true);
-
-                if use_blur {
-                    if lyric_transition < 1.0 && !old_lyric.is_empty() {
-                        let mut text_paint = Paint::default();
-                        text_paint.set_anti_alias(true);
-                        let fade_alpha = (alpha as f32 * (1.0 - lyric_transition)) as u8;
-                        text_paint.set_color(Color::from_argb(
-                            fade_alpha,
-                            text_color.r(),
-                            text_color.g(),
-                            text_color.b(),
-                        ));
-
-                        let blur_sigma = lyric_transition * 12.0 * global_scale;
-                        if blur_sigma > 0.1 {
-                            text_paint.set_image_filter(image_filters::blur(
-                                (blur_sigma, 0.0),
-                                None,
-                                None,
-                                None,
-                            ));
-                        }
-
-                        let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale
-                            - (10.0 * global_scale * lyric_transition);
-                        let old_lx = if text_centered {
-                            let w = FontManager::global().measure_text_cached(
-                                old_lyric,
-                                lyric_font_sz,
-                                skia_safe::FontStyle::normal(),
-                            );
-                            text_x - w / 2.0
-                        } else {
-                            text_x
-                        };
-                        draw_text_cached(DrawTextCachedParams {
-                            canvas,
-                            text: old_lyric,
-                            x: old_lx,
-                            y: text_y,
-                            size: lyric_font_sz,
-                            bold: false,
-                            paint: &text_paint,
-                        });
-                    }
-
-                    if !current_lyric.is_empty() {
-                        let mut text_paint = Paint::default();
-                        text_paint.set_anti_alias(true);
-                        let fade_alpha = (alpha as f32 * lyric_transition) as u8;
-                        text_paint.set_color(Color::from_argb(
-                            fade_alpha,
-                            text_color.r(),
-                            text_color.g(),
-                            text_color.b(),
-                        ));
-
-                        let blur_sigma = (1.0 - lyric_transition) * 12.0 * global_scale;
-                        if blur_sigma > 0.1 {
-                            text_paint.set_image_filter(image_filters::blur(
-                                (blur_sigma, 0.0),
-                                None,
-                                None,
-                                None,
-                            ));
-                        }
-
-                        let text_y = offset_y
-                            + current_h / 2.0
-                            + 4.0 * global_scale
-                            + (10.0 * global_scale * (1.0 - lyric_transition));
-                        let cur_lx = if text_centered {
-                            let w = FontManager::global().measure_text_cached(
-                                current_lyric,
-                                lyric_font_sz,
-                                skia_safe::FontStyle::normal(),
-                            );
-                            text_x - w / 2.0
-                        } else {
-                            text_x
-                        };
-                        draw_text_cached(DrawTextCachedParams {
-                            canvas,
-                            text: current_lyric,
-                            x: cur_lx,
-                            y: text_y,
-                            size: lyric_font_sz,
-                            bold: false,
-                            paint: &text_paint,
-                        });
-                    }
-                } else {
-                    let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale;
-                    if lyric_transition < 0.5 && !old_lyric.is_empty() {
-                        let mut text_paint = Paint::default();
-                        text_paint.set_anti_alias(true);
-                        let progress = lyric_transition * 2.0;
-                        let fade_alpha = (alpha as f32 * (1.0 - progress)) as u8;
-                        text_paint.set_color(Color::from_argb(
-                            fade_alpha,
-                            text_color.r(),
-                            text_color.g(),
-                            text_color.b(),
-                        ));
-                        let old_lx2 = if text_centered {
-                            let w = FontManager::global().measure_text_cached(
-                                old_lyric,
-                                lyric_font_sz,
-                                skia_safe::FontStyle::normal(),
-                            );
-                            text_x - w / 2.0
-                        } else {
-                            text_x
-                        };
-                        draw_text_cached(DrawTextCachedParams {
-                            canvas,
-                            text: old_lyric,
-                            x: old_lx2,
-                            y: text_y,
-                            size: lyric_font_sz,
-                            bold: false,
-                            paint: &text_paint,
-                        });
-                    } else if lyric_transition >= 0.5 && !current_lyric.is_empty() {
-                        let mut text_paint = Paint::default();
-                        text_paint.set_anti_alias(true);
-                        let progress = (lyric_transition - 0.5) * 2.0;
-                        let fade_alpha = (alpha as f32 * progress) as u8;
-                        text_paint.set_color(Color::from_argb(
-                            fade_alpha,
-                            text_color.r(),
-                            text_color.g(),
-                            text_color.b(),
-                        ));
-                        let cur_lx2 = if text_centered {
-                            let w = FontManager::global().measure_text_cached(
-                                current_lyric,
-                                lyric_font_sz,
-                                skia_safe::FontStyle::normal(),
-                            );
-                            text_x - w / 2.0
-                        } else {
-                            text_x
-                        };
-                        draw_text_cached(DrawTextCachedParams {
-                            canvas,
-                            text: current_lyric,
-                            x: cur_lx2,
-                            y: text_y,
-                            size: lyric_font_sz,
-                            bold: false,
-                            paint: &text_paint,
-                        });
-                    }
+                    canvas.save();
+                    canvas.translate((center_x, center_y));
+                    draw_play_button(canvas, 0.0, 0.0, ctrl_alpha, btn_scale, text_color);
+                    canvas.restore();
                 }
-                canvas.restore();
+            } else if !current_lyric.is_empty() || !old_lyric.is_empty() {
+                let lyric_fade_f = (1.0 - expansion_progress * 2.5).clamp(0.0, 1.0);
+                let alpha = (alpha as f32 * lyric_fade_f) as u8;
+
+                if alpha > 0 {
+                    let lyric_font_sz = if font_size > 0.0 {
+                        font_size * 0.8 * global_scale
+                    } else {
+                        12.0 * global_scale
+                    };
+                    let space_left = offset_x + 30.0 * global_scale;
+                    let space_right = offset_x + current_w - 29.0 * global_scale;
+                    let available_w = space_right - space_left;
+                    let scrolling = lyric_scroll_offset > 0.0;
+                    let text_x = if scrolling {
+                        space_left - lyric_scroll_offset
+                    } else {
+                        space_left + available_w / 2.0
+                    };
+                    let text_centered = !scrolling;
+
+                    canvas.save();
+                    let clip_rect = Rect::from_xywh(space_left, offset_y, available_w, current_h);
+                    canvas.clip_rect(clip_rect, ClipOp::Intersect, true);
+
+                    if use_blur {
+                        if lyric_transition < 1.0 && !old_lyric.is_empty() {
+                            let mut text_paint = Paint::default();
+                            text_paint.set_anti_alias(true);
+                            let fade_alpha = (alpha as f32 * (1.0 - lyric_transition)) as u8;
+                            text_paint.set_color(Color::from_argb(
+                                fade_alpha,
+                                text_color.r(),
+                                text_color.g(),
+                                text_color.b(),
+                            ));
+
+                            let blur_sigma = lyric_transition * 12.0 * global_scale;
+                            if blur_sigma > 0.1 {
+                                text_paint.set_image_filter(image_filters::blur(
+                                    (blur_sigma, 0.0),
+                                    None,
+                                    None,
+                                    None,
+                                ));
+                            }
+
+                            let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale
+                                - (10.0 * global_scale * lyric_transition);
+                            let old_lx = if text_centered {
+                                let w = FontManager::global().measure_text_cached(
+                                    old_lyric,
+                                    lyric_font_sz,
+                                    skia_safe::FontStyle::normal(),
+                                );
+                                text_x - w / 2.0
+                            } else {
+                                text_x
+                            };
+                            draw_text_cached(DrawTextCachedParams {
+                                canvas,
+                                text: old_lyric,
+                                x: old_lx,
+                                y: text_y,
+                                size: lyric_font_sz,
+                                bold: false,
+                                paint: &text_paint,
+                            });
+                        }
+
+                        if !current_lyric.is_empty() {
+                            let mut text_paint = Paint::default();
+                            text_paint.set_anti_alias(true);
+                            let fade_alpha = (alpha as f32 * lyric_transition) as u8;
+                            text_paint.set_color(Color::from_argb(
+                                fade_alpha,
+                                text_color.r(),
+                                text_color.g(),
+                                text_color.b(),
+                            ));
+
+                            let blur_sigma = (1.0 - lyric_transition) * 12.0 * global_scale;
+                            if blur_sigma > 0.1 {
+                                text_paint.set_image_filter(image_filters::blur(
+                                    (blur_sigma, 0.0),
+                                    None,
+                                    None,
+                                    None,
+                                ));
+                            }
+
+                            let text_y = offset_y
+                                + current_h / 2.0
+                                + 4.0 * global_scale
+                                + (10.0 * global_scale * (1.0 - lyric_transition));
+                            let cur_lx = if text_centered {
+                                let w = FontManager::global().measure_text_cached(
+                                    current_lyric,
+                                    lyric_font_sz,
+                                    skia_safe::FontStyle::normal(),
+                                );
+                                text_x - w / 2.0
+                            } else {
+                                text_x
+                            };
+                            draw_text_cached(DrawTextCachedParams {
+                                canvas,
+                                text: current_lyric,
+                                x: cur_lx,
+                                y: text_y,
+                                size: lyric_font_sz,
+                                bold: false,
+                                paint: &text_paint,
+                            });
+                        }
+                    } else {
+                        let text_y = offset_y + current_h / 2.0 + 4.0 * global_scale;
+                        if lyric_transition < 0.5 && !old_lyric.is_empty() {
+                            let mut text_paint = Paint::default();
+                            text_paint.set_anti_alias(true);
+                            let progress = lyric_transition * 2.0;
+                            let fade_alpha = (alpha as f32 * (1.0 - progress)) as u8;
+                            text_paint.set_color(Color::from_argb(
+                                fade_alpha,
+                                text_color.r(),
+                                text_color.g(),
+                                text_color.b(),
+                            ));
+                            let old_lx2 = if text_centered {
+                                let w = FontManager::global().measure_text_cached(
+                                    old_lyric,
+                                    lyric_font_sz,
+                                    skia_safe::FontStyle::normal(),
+                                );
+                                text_x - w / 2.0
+                            } else {
+                                text_x
+                            };
+                            draw_text_cached(DrawTextCachedParams {
+                                canvas,
+                                text: old_lyric,
+                                x: old_lx2,
+                                y: text_y,
+                                size: lyric_font_sz,
+                                bold: false,
+                                paint: &text_paint,
+                            });
+                        } else if lyric_transition >= 0.5 && !current_lyric.is_empty() {
+                            let mut text_paint = Paint::default();
+                            text_paint.set_anti_alias(true);
+                            let progress = (lyric_transition - 0.5) * 2.0;
+                            let fade_alpha = (alpha as f32 * progress) as u8;
+                            text_paint.set_color(Color::from_argb(
+                                fade_alpha,
+                                text_color.r(),
+                                text_color.g(),
+                                text_color.b(),
+                            ));
+                            let cur_lx2 = if text_centered {
+                                let w = FontManager::global().measure_text_cached(
+                                    current_lyric,
+                                    lyric_font_sz,
+                                    skia_safe::FontStyle::normal(),
+                                );
+                                text_x - w / 2.0
+                            } else {
+                                text_x
+                            };
+                            draw_text_cached(DrawTextCachedParams {
+                                canvas,
+                                text: current_lyric,
+                                x: cur_lx2,
+                                y: text_y,
+                                size: lyric_font_sz,
+                                bold: false,
+                                paint: &text_paint,
+                            });
+                        }
+                    }
+                    canvas.restore();
+                }
             }
+        } else if let Some(plugin_text) = plugin.title {
+            let font_sz = if font_size > 0.0 {
+                font_size * 0.7 * global_scale
+            } else {
+                11.0 * global_scale
+            };
+            let alpha = (mini_alpha_f * 255.0) as u8;
+            let mut text_paint = Paint::default();
+            text_paint.set_anti_alias(true);
+            text_paint.set_color(Color::from_argb(
+                alpha,
+                text_color.r(),
+                text_color.g(),
+                text_color.b(),
+            ));
+            let text_x = offset_x + 20.0 * global_scale;
+            let text_w = current_w - 40.0 * global_scale;
+            let text_y = offset_y + current_h / 2.0 - font_sz * 0.3;
+            canvas.save();
+            let clip = Rect::from_xywh(text_x, offset_y, text_w, current_h);
+            canvas.clip_rect(clip, ClipOp::Intersect, true);
+            draw_text_cached(DrawTextCachedParams {
+                canvas,
+                text: plugin_text,
+                x: text_x,
+                y: text_y,
+                size: font_sz,
+                bold: true,
+                paint: &text_paint,
+            });
+            if let Some(msg) = plugin.message {
+                let sec_font_sz = font_sz * 0.8;
+                let mut sec_paint = Paint::default();
+                sec_paint.set_anti_alias(true);
+                sec_paint.set_color(Color::from_argb(
+                    (alpha as f32 * 0.7) as u8,
+                    text_color.r(),
+                    text_color.g(),
+                    text_color.b(),
+                ));
+                let sec_y = text_y + font_sz * 1.3;
+                draw_text_cached(DrawTextCachedParams {
+                    canvas,
+                    text: msg,
+                    x: text_x,
+                    y: sec_y,
+                    size: sec_font_sz,
+                    bold: false,
+                    paint: &sec_paint,
+                });
+            }
+            canvas.restore();
         }
     }
     canvas.restore();

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -147,6 +147,18 @@ impl NativePlugin {
         // SAFETY: vtable was validated on construction and is 'static in the DLL.
         unsafe { &*self.vtable }
     }
+
+    /// Give this plugin a pointer to the host API table.
+    pub fn set_host_api(&self, api: super::types::HostApiC) {
+        if let Some(f) = self.vtable().set_host_api {
+            unsafe { (f)(self.handle, &api as *const _) };
+        }
+    }
+
+    /// Raw handle pointer value, used as a key in plugin→id mapping.
+    pub fn handle_raw(&self) -> isize {
+        self.handle as isize
+    }
 }
 
 impl Plugin for NativePlugin {

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -5,8 +5,160 @@ use super::types::{
     ContentProvider, Plugin, PluginError, PluginType, ShortcutProvider, ThemeProvider,
 };
 use super::zip_loader::{self, PluginManifest};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
+use std::sync::{Mutex, OnceLock};
+
+// ---------------------------------------------------------------------------
+// Global router — C callbacks route through thread-safe pending buffers
+// ---------------------------------------------------------------------------
+
+static PENDING_CONTEXTS: OnceLock<Mutex<Vec<crate::core::context::PluginContext>>> =
+    OnceLock::new();
+static PENDING_CLOSE: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+static PLUGIN_HANDLES: OnceLock<Mutex<HashMap<isize, String>>> = OnceLock::new();
+static HOST_STATE: OnceLock<Mutex<crate::plugin::types::HostState>> = OnceLock::new();
+
+/// Initialise the global plugin→host routing. Must be called once at startup.
+pub fn init_host_api() -> crate::plugin::types::HostApiC {
+    PENDING_CONTEXTS.get_or_init(|| Mutex::new(Vec::new()));
+    PENDING_CLOSE.get_or_init(|| Mutex::new(Vec::new()));
+    PLUGIN_HANDLES.get_or_init(|| Mutex::new(HashMap::new()));
+    HOST_STATE.get_or_init(|| Mutex::new(crate::plugin::types::HostState::default()));
+
+    crate::plugin::types::HostApiC {
+        send_context: host_send_context,
+        close_context: host_close_context,
+        query_host_state: host_query_host_state,
+    }
+}
+
+/// Drain all pending plugin contexts and push them into the ContextManager.
+/// Called once per frame from the main loop.
+pub fn drain_pending_contexts(ctx_mgr: &mut crate::core::context::ContextManager) {
+    if let Some(buf) = PENDING_CONTEXTS.get()
+        && let Ok(mut v) = buf.lock()
+    {
+        for ctx in v.drain(..) {
+            ctx_mgr.push_context(ctx);
+        }
+    }
+    if let Some(buf) = PENDING_CLOSE.get()
+        && let Ok(mut v) = buf.lock()
+    {
+        for encoded in v.drain(..) {
+            if let Some(id) = crate::core::context::ContextId::from_encoded(&encoded) {
+                ctx_mgr.close_context(&id);
+            }
+        }
+    }
+}
+
+/// Register a plugin handle → plugin_id mapping.
+pub fn register_plugin_handle(handle: isize, plugin_id: &str) {
+    if let Some(map) = PLUGIN_HANDLES.get()
+        && let Ok(mut m) = map.lock()
+    {
+        m.insert(handle, plugin_id.to_string());
+    }
+}
+
+/// Remove a plugin handle mapping on unload.
+pub fn deregister_plugin_handle(handle: isize) {
+    if let Some(map) = PLUGIN_HANDLES.get()
+        && let Ok(mut m) = map.lock()
+    {
+        m.remove(&handle);
+    }
+}
+
+/// Update the cached host state (called from app.rs when SMTC changes).
+pub fn update_host_state(state: crate::plugin::types::HostState) {
+    if let Some(s) = HOST_STATE.get()
+        && let Ok(mut m) = s.lock()
+    {
+        *m = state;
+    }
+}
+
+unsafe extern "C" fn host_send_context(
+    handle: crate::plugin::types::PluginHandle,
+    data: crate::plugin::types::ContextDataC,
+) -> crate::plugin::types::ContextIdC {
+    let plugin_id = PLUGIN_HANDLES
+        .get()
+        .and_then(|m| m.lock().ok())
+        .and_then(|m| m.get(&(handle as isize)).cloned())
+        .unwrap_or_default();
+
+    let mut ctx = crate::core::context::PluginContext::from(&data);
+    ctx.id.source = plugin_id.clone();
+
+    let encoded_id = if let Some(buf) = PENDING_CONTEXTS.get()
+        && let Ok(mut v) = buf.lock()
+    {
+        ctx.id.uuid = crate::core::context::ContextId::new(&plugin_id).uuid;
+        let encoded = ctx.id.encode();
+        v.push(ctx);
+        encoded
+    } else {
+        String::new()
+    };
+
+    let mut id_buf = [0u8; 128];
+    let len = encoded_id.len().min(127);
+    id_buf[..len].copy_from_slice(encoded_id.as_bytes());
+    crate::plugin::types::ContextIdC { id: id_buf }
+}
+
+unsafe extern "C" fn host_close_context(
+    handle: crate::plugin::types::PluginHandle,
+    id_str: *const std::ffi::c_char,
+) -> crate::plugin::types::PluginResultC {
+    let raw = unsafe { std::ffi::CStr::from_ptr(id_str) };
+    let s = raw.to_string_lossy();
+    if let Some(context_id) = crate::core::context::ContextId::from_encoded(&s) {
+        let plugin_id = PLUGIN_HANDLES
+            .get()
+            .and_then(|m| m.lock().ok())
+            .and_then(|m| m.get(&(handle as isize)).cloned())
+            .unwrap_or_default();
+        // Only allow closing own contexts
+        if context_id.source != plugin_id {
+            return crate::plugin::types::PluginResultC::err(
+                "Cannot close another plugin's context",
+            );
+        }
+        if let Some(buf) = PENDING_CLOSE.get()
+            && let Ok(mut v) = buf.lock()
+        {
+            v.push(context_id.encode());
+        }
+        crate::plugin::types::PluginResultC::ok()
+    } else {
+        crate::plugin::types::PluginResultC::err("Invalid context ID format")
+    }
+}
+
+unsafe extern "C" fn host_query_host_state(
+    _handle: crate::plugin::types::PluginHandle,
+) -> crate::plugin::types::HostStateC {
+    HOST_STATE
+        .get()
+        .and_then(|m| m.lock().ok())
+        .map(|m| crate::plugin::types::HostStateC::from(&*m))
+        .unwrap_or_else(|| crate::plugin::types::HostStateC {
+            media_title: [0u8; 256],
+            media_artist: [0u8; 256],
+            is_playing: false,
+            theme: [0u8; 32],
+        })
+}
+
+// ---------------------------------------------------------------------------
+// PluginManager
+// ---------------------------------------------------------------------------
 
 pub struct PluginManager {
     entries: RwLock<Vec<NativePlugin>>,
@@ -166,6 +318,22 @@ impl PluginManager {
             .filter(|p| p.plugin_type() == PluginType::Shortcut)
             .map(|p| p.metadata().id.clone())
             .collect()
+    }
+
+    /// Call `set_host_api` on every loaded plugin and register its handle.
+    pub fn init_plugin_host_api(&self, api: crate::plugin::types::HostApiC) {
+        let entries = match self.entries.read() {
+            Ok(g) => g,
+            Err(e) => {
+                log::error!("Plugin lock poisoned: {}", e);
+                return;
+            }
+        };
+        for plugin in entries.iter() {
+            let handle = plugin.handle_raw();
+            plugin.set_host_api(api);
+            register_plugin_handle(handle, &plugin.metadata().id);
+        }
     }
 
     pub fn with_content<F, R>(&self, plugin_id: &str, f: F) -> Result<R, PluginError>

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -260,6 +260,19 @@ impl PluginManager {
         Ok(f(entry))
     }
 
+    /// Iterate over all content plugins and call `f` with each one.
+    /// Stops early if `f` returns `Some<T>` on any plugin.
+    pub fn find_content<F, T>(&self, mut f: F) -> Option<T>
+    where
+        F: FnMut(&mut dyn ContentProvider) -> Option<T>,
+    {
+        let mut entries = self.entries.write().ok()?;
+        entries
+            .iter_mut()
+            .filter(|p| p.plugin_type() == PluginType::Content)
+            .find_map(|entry| f(entry as &mut dyn ContentProvider))
+    }
+
     pub fn plugin_dir(&self) -> &Path {
         &self.plugin_dir
     }

--- a/src/plugin/types.rs
+++ b/src/plugin/types.rs
@@ -3,8 +3,9 @@
 use serde::{Deserialize, Serialize};
 
 pub use winisland_plugin_api::{
-    AnimationConfigC, ISLAND_CONTENT_TAG_MUSIC, ISLAND_CONTENT_TAG_NOTIFICATION,
-    ISLAND_CONTENT_TAG_STATUS, IslandContentC, PluginGetInstanceFn, PluginHandle, PluginInstanceC,
+    AnimationConfigC, ContextDataC, ContextIdC, HostApiC, HostStateC, ISLAND_CONTENT_TAG_MUSIC,
+    ISLAND_CONTENT_TAG_NOTIFICATION, ISLAND_CONTENT_TAG_STATUS, IslandContentC, PRIORITY_HIGH,
+    PRIORITY_LOW, PRIORITY_MEDIUM, PluginGetInstanceFn, PluginHandle, PluginInstanceC,
     PluginMetadataC, PluginResultC, PluginType, PluginVTable, ShortcutC, ThemeColorsC,
 };
 
@@ -204,4 +205,78 @@ pub trait ThemeProvider: Plugin {
 pub trait ShortcutProvider: Plugin {
     fn get_shortcuts(&self) -> Vec<Shortcut>;
     fn execute(&mut self, shortcut_id: &str) -> Result<(), String>;
+}
+
+// ---------------------------------------------------------------------------
+// Context types (push-based, Host side)
+// ---------------------------------------------------------------------------
+
+/// Host state snapshot returned by [`HostApiC::query_host_state`].
+#[derive(Debug, Clone, Default)]
+pub struct HostState {
+    pub media_title: String,
+    pub media_artist: String,
+    pub is_playing: bool,
+    pub theme: String,
+}
+
+impl From<&HostStateC> for HostState {
+    fn from(c: &HostStateC) -> Self {
+        Self {
+            media_title: read_c_str(&c.media_title),
+            media_artist: read_c_str(&c.media_artist),
+            is_playing: c.is_playing,
+            theme: read_c_str(&c.theme),
+        }
+    }
+}
+
+impl From<&HostState> for HostStateC {
+    fn from(s: &HostState) -> Self {
+        fn fill<const N: usize>(buf: &mut [u8; N], val: &str) {
+            let len = val.len().min(N - 1);
+            buf[..len].copy_from_slice(&val.as_bytes()[..len]);
+        }
+        let mut c = HostStateC {
+            media_title: [0u8; 256],
+            media_artist: [0u8; 256],
+            is_playing: s.is_playing,
+            theme: [0u8; 32],
+        };
+        fill(&mut c.media_title, &s.media_title);
+        fill(&mut c.media_artist, &s.media_artist);
+        fill(&mut c.theme, &s.theme);
+        c
+    }
+}
+
+/// Convert a C ABI [`ContextDataC`] into a [`HostState`] (host-side context data).
+///
+/// Note: The priority field is mapped directly from the C-level constant.
+impl From<&ContextDataC> for crate::core::context::PluginContext {
+    fn from(c: &ContextDataC) -> Self {
+        let priority = match c.priority {
+            PRIORITY_LOW => crate::core::context::Priority::Low,
+            PRIORITY_MEDIUM => crate::core::context::Priority::Medium,
+            PRIORITY_HIGH => crate::core::context::Priority::High,
+            _ => crate::core::context::Priority::Medium,
+        };
+        Self {
+            id: crate::core::context::ContextId {
+                source: String::new(), // filled in by the caller
+                uuid: String::new(),   // filled in by ContextManager::push_context
+            },
+            priority,
+            title: read_c_str(&c.title),
+            body: read_c_str(&c.body),
+            icon: Vec::new(), // filled from plugin metadata later
+            duration_sec: c.duration_sec,
+            mini_render: c.mini_render,
+            mini_text: read_c_str(&c.mini_text),
+            created_at: std::time::Instant::now(),
+            expanded_started_at: None,
+            collapsed_at: None,
+            mini_timeout_start: None,
+        }
+    }
 }

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -876,6 +876,8 @@ impl ApplicationHandler for App {
                 + self.plugin_mgr.list_theme_providers().len()
                 + self.plugin_mgr.list_shortcut_providers().len();
             log::info!("{} plugin(s) loaded", plugin_count);
+            let host_api = crate::plugin::manager::init_host_api();
+            self.plugin_mgr.init_plugin_host_api(host_api);
             let max_w = self.config.expanded_width.max(450.0);
             self.os_w = (max_w * self.config.global_scale + PADDING) as u32;
             self.os_h = (self.config.expanded_height * self.config.global_scale + PADDING) as u32;
@@ -1143,6 +1145,7 @@ impl ApplicationHandler for App {
                             music_active = true;
                         }
                         self.ctx_mgr.set_smtc_active(music_active);
+                        crate::plugin::manager::drain_pending_contexts(&mut self.ctx_mgr);
                         self.ctx_mgr.tick();
                         let mini_content = self.ctx_mgr.current_mini();
 

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -1,5 +1,6 @@
 use crate::core::audio::AudioProcessor;
 use crate::core::config::{AppConfig, PADDING, TOP_OFFSET, WINDOW_TITLE};
+use crate::core::context::ContextManager;
 use crate::core::persistence::load_config;
 use crate::core::render::{draw_island, get_mini_control_rects};
 use crate::core::smtc::SmtcListener;
@@ -93,6 +94,7 @@ pub struct App {
     is_cursor_suppressed: bool,
     touch_id: Option<u64>,
     touch_pos: PhysicalPosition<f64>,
+    ctx_mgr: ContextManager,
     plugin_mgr: PluginManager,
     pending_install: Option<mpsc::Receiver<InstallResult>>,
 }
@@ -153,6 +155,7 @@ impl Default for App {
             is_cursor_suppressed: false,
             touch_id: None,
             touch_pos: PhysicalPosition::new(0.0, 0.0),
+            ctx_mgr: ContextManager::new(),
             plugin_mgr: PluginManager::default(),
             pending_install: None,
         }
@@ -1139,34 +1142,9 @@ impl ApplicationHandler for App {
                         if self.config.smtc_enabled && !media_info.title.is_empty() {
                             music_active = true;
                         }
-
-                        let plugin_text: Option<(String, Option<String>)> = if !music_active {
-                            self.plugin_mgr.find_content(|provider| {
-                                match provider.get_content()? {
-                                    crate::plugin::types::IslandContent::Notification {
-                                        title,
-                                        message,
-                                        ..
-                                    } => Some((title, Some(message))),
-                                    crate::plugin::types::IslandContent::Status {
-                                        label,
-                                        value,
-                                        ..
-                                    } => Some((label, Some(value))),
-                                    crate::plugin::types::IslandContent::Music {
-                                        title,
-                                        artist,
-                                        ..
-                                    } => Some((title, Some(artist))),
-                                    crate::plugin::types::IslandContent::Shortcut {
-                                        name, ..
-                                    } => Some((name, None)),
-                                    crate::plugin::types::IslandContent::Custom(_) => None,
-                                }
-                            })
-                        } else {
-                            None
-                        };
+                        self.ctx_mgr.set_smtc_active(music_active);
+                        self.ctx_mgr.tick();
+                        let mini_content = self.ctx_mgr.current_mini();
 
                         let widget_animating = draw_island(
                             surface,
@@ -1214,10 +1192,7 @@ impl ApplicationHandler for App {
                                     lyrics_delay: self.config.lyrics_delay,
                                     dt,
                                 },
-                                plugin: crate::core::render::PluginTextParams {
-                                    title: plugin_text.as_ref().map(|(t, _)| t.as_str()),
-                                    message: plugin_text.as_ref().and_then(|(_, m)| m.as_deref()),
-                                },
+                                mini_content,
                             },
                         );
                         if widget_animating && let Some(win) = &self.window {

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -1140,6 +1140,34 @@ impl ApplicationHandler for App {
                             music_active = true;
                         }
 
+                        let plugin_text: Option<(String, Option<String>)> = if !music_active {
+                            self.plugin_mgr.find_content(|provider| {
+                                match provider.get_content()? {
+                                    crate::plugin::types::IslandContent::Notification {
+                                        title,
+                                        message,
+                                        ..
+                                    } => Some((title, Some(message))),
+                                    crate::plugin::types::IslandContent::Status {
+                                        label,
+                                        value,
+                                        ..
+                                    } => Some((label, Some(value))),
+                                    crate::plugin::types::IslandContent::Music {
+                                        title,
+                                        artist,
+                                        ..
+                                    } => Some((title, Some(artist))),
+                                    crate::plugin::types::IslandContent::Shortcut {
+                                        name, ..
+                                    } => Some((name, None)),
+                                    crate::plugin::types::IslandContent::Custom(_) => None,
+                                }
+                            })
+                        } else {
+                            None
+                        };
+
                         let widget_animating = draw_island(
                             surface,
                             crate::core::render::DrawIslandParams {
@@ -1185,6 +1213,10 @@ impl ApplicationHandler for App {
                                     mini_controls: self.config.mini_controls,
                                     lyrics_delay: self.config.lyrics_delay,
                                     dt,
+                                },
+                                plugin: crate::core::render::PluginTextParams {
+                                    title: plugin_text.as_ref().map(|(t, _)| t.as_str()),
+                                    message: plugin_text.as_ref().and_then(|(_, m)| m.as_deref()),
                                 },
                             },
                         );


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `CONTRIBUTING.md` 并完成要求测试
- [x] 本地/CI 测试通过（cargo check + clippy + fmt 零错误零警告）
- [x] 代码审查 (Self-review) 完成

## pr方向 (一定要选其中一个)

- [x] `feat` 新功能

## 影响范围（可多选）
- [x] 程序核心 Core
    - [ ] UI 样式/布局
    - [x] 功能逻辑
    - [ ] 依赖变更 (package.json)
    - [ ] 其他

- [x] 后端 Backend
    - [x] 插件 API 接口变更

## 关联 Issue

无

---

## pr内容

### 摘要

为 Dynamic Island 引入统一的 ContextManager 调度器，实现插件向宿主 push context 的双向通信通道（HostApiC），SMTC 音乐和插件内容由同一调度器仲裁显示优先级。

### 动机/背景

在 P0 实现了 Content Plugin 的渲染框架后，插件内容与 SMTC 音乐内容在 mini view 上竞争同一个显示槽位。旧的架构使用 `if music_active` 硬编码判断，缺乏优先级仲裁和生命周期管理，且插件内容只能通过轮询拉取。

本次 PR 将内容调度下沉到统一的 **ContextManager**，并采用 **push-based** 的插件通信模型——插件通过 `HostApiC` 函数表随时向宿主推送/关闭 context，宿主主线程每帧 drain 后统一仲裁优先级和超时。

### 具体改动

**架构数据流**

```
plugin DLL (任意线程)
  └─ HostApiC 函数表
      ├─ send_context(ctx)       → PENDING_CONTEXTS[buffer]
      ├─ close_context(id)       → PENDING_CLOSE[buffer]
      └─ query_host_state()      → HOST_STATE[snapshot]

WinIsland 主线程（每帧）
  about_to_wait:
    drain_pending_contexts(&mut ctx_mgr)
    ctx_mgr.tick()              ← 超时检查
    ctx_mgr.current_mini()      → render() match MiniContent
```

**模块划分**

| 模块 | 说明 |
|------|------|
| `src/core/context/` | **新建** ContextManager 调度器、MiniContent 枚举、Priority 三级优先级、PluginContext/ContextId 类型 |
| `crates/.../lib.rs` | **API 新增** ContextDataC、ContextIdC、HostStateC、HostApiC（含 send_context / close_context / query_host_state）+ set_host_api vtable slot |
| `src/plugin/types.rs` | HostState 类型及其 C ABI 互转、ContextDataC → PluginContext 转换 |
| `src/plugin/manager.rs` | 全局 pending buffer（Mutex<Vec>）、drain_pending_contexts()、handle registry |
| `src/plugin/loader.rs` | NativePlugin::set_host_api()、handle_raw() |
| `src/window/app.rs` | 插件加载后 init_host_api + init_plugin_host_api、每帧 drain_pending_contexts |
| `src/core/render.rs` | PluginTextParams → mini_content: Option<MiniContent>、if music_active → match 表达式 |

**关键设计决策**

- **pending buffer 模式**：插件可能运行在任意线程，FFI 回调写入 Mutex<Vec> pending buffer，主线程单帧 drain，避免 ContextManager 的 &mut self 跨线程问题
- **安全约束**：host_close_context 校验 context_id.source == plugin_id，插件不能关闭其他插件的 context
- **HostApiC 为 repr(C) + Clone + Copy**：函数指针表可安全地在 FFI 边界传递和存储

### 界面变动

无界面改动。mini view 的渲染逻辑保持与之前一致（仅 dispatch 方式从 `if music_active` 变为 `match &mini_content`）。