### PR TITLE
feat(plugin): add MediaSourceC for plugin media source injection

### DIFF
--- a/crates/winisland-plugin-api/src/lib.rs
+++ b/crates/winisland-plugin-api/src/lib.rs
@@ -290,6 +290,32 @@ pub struct HostStateC {
     pub theme: [u8; 32],
 }
 
+/// Media source data pushed by a plugin to replace SMTC playback info.
+///
+/// When a plugin calls `set_media_source`, the host uses this data
+/// instead of the current SMTC session for the entire media UI
+/// (progress bar, cover art, title/artist, playback controls).
+/// Call `clear_media_source` to restore SMTC as the source.
+#[repr(C)]
+pub struct MediaSourceC {
+    /// Track title. Max 255 bytes + NUL.
+    pub title: [u8; 256],
+    /// Artist name. Max 255 bytes + NUL.
+    pub artist: [u8; 256],
+    /// Album name. Max 255 bytes + NUL.
+    pub album: [u8; 256],
+    /// Total duration in milliseconds.
+    pub duration_ms: u64,
+    /// Current playback position in milliseconds.
+    pub position_ms: u64,
+    /// Whether the media is currently playing.
+    pub is_playing: bool,
+    /// Raw cover art bytes (JPEG/PNG). Null pointer if no cover.
+    pub cover_data: *const u8,
+    /// Length of `cover_data` in bytes. 0 if no cover.
+    pub cover_len: u32,
+}
+
 /// Host-side API table passed to plugins via [`PluginVTable::set_host_api`].
 ///
 /// Plugins store this pointer during `set_host_api` and call through it
@@ -308,6 +334,15 @@ pub struct HostApiC {
 
     /// Query the current host state.
     pub query_host_state: unsafe extern "C" fn(PluginHandle) -> HostStateC,
+
+    /// Replace SMTC with plugin-provided media source.
+    ///
+    /// The host will use this data for the entire media UI. Returns an
+    /// error if `title` is empty. Call [`clear_media_source`] to restore SMTC.
+    pub set_media_source: unsafe extern "C" fn(PluginHandle, MediaSourceC) -> PluginResultC,
+
+    /// Restore SMTC as the active media source and stop using plugin data.
+    pub clear_media_source: unsafe extern "C" fn(PluginHandle) -> PluginResultC,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -149,9 +149,21 @@ impl NativePlugin {
     }
 
     /// Give this plugin a pointer to the host API table.
-    pub fn set_host_api(&self, api: super::types::HostApiC) {
-        if let Some(f) = self.vtable().set_host_api {
-            unsafe { (f)(self.handle, &api as *const _) };
+    ///
+    /// Looks for a `plugin_set_host_api` symbol exported by the DLL.
+    /// If the plugin doesn't export it (old plugin), this is a no-op.
+    /// The pointer must be `'static` (leaked or global).
+    pub fn set_host_api(&self, api: *const super::types::HostApiC) {
+        // Try to find the `plugin_set_host_api` symbol exported by the DLL.
+        // Old plugins don't export it — this is a no-op for those.
+        let lib: &Library = &self._lib;
+        if let Ok(func) = unsafe {
+            lib.get::<unsafe extern "C" fn(
+                crate::plugin::types::PluginHandle,
+                *const crate::plugin::types::HostApiC,
+            )>(b"plugin_set_host_api\0")
+        } {
+            unsafe { (func)(self.handle, api) };
         }
     }
 

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -32,22 +32,30 @@ static PENDING_CLOSE: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 static PENDING_MEDIA_SOURCE: OnceLock<Mutex<Option<PendingMediaSource>>> = OnceLock::new();
 static PLUGIN_HANDLES: OnceLock<Mutex<HashMap<isize, String>>> = OnceLock::new();
 static HOST_STATE: OnceLock<Mutex<crate::plugin::types::HostState>> = OnceLock::new();
+/// Leaked `'static` HostApiC — plugins hold a raw pointer to this.
+static HOST_API: OnceLock<Box<crate::plugin::types::HostApiC>> = OnceLock::new();
 
 /// Initialise the global plugin→host routing. Must be called once at startup.
-pub fn init_host_api() -> crate::plugin::types::HostApiC {
+///
+/// Returns a `*const` to a leaked `'static` HostApiC that plugins can safely
+/// store and call through for the entire process lifetime.
+pub fn init_host_api() -> *const crate::plugin::types::HostApiC {
     PENDING_CONTEXTS.get_or_init(|| Mutex::new(Vec::new()));
     PENDING_CLOSE.get_or_init(|| Mutex::new(Vec::new()));
     PENDING_MEDIA_SOURCE.get_or_init(|| Mutex::new(None));
     PLUGIN_HANDLES.get_or_init(|| Mutex::new(HashMap::new()));
     HOST_STATE.get_or_init(|| Mutex::new(crate::plugin::types::HostState::default()));
 
-    crate::plugin::types::HostApiC {
-        send_context: host_send_context,
-        close_context: host_close_context,
-        query_host_state: host_query_host_state,
-        set_media_source: host_set_media_source,
-        clear_media_source: host_clear_media_source,
-    }
+    let api = HOST_API.get_or_init(|| {
+        Box::new(crate::plugin::types::HostApiC {
+            send_context: host_send_context,
+            close_context: host_close_context,
+            query_host_state: host_query_host_state,
+            set_media_source: host_set_media_source,
+            clear_media_source: host_clear_media_source,
+        })
+    });
+    api.as_ref() as *const _
 }
 
 /// Drain all pending plugin contexts and push them into the ContextManager.
@@ -384,7 +392,7 @@ impl PluginManager {
     }
 
     /// Call `set_host_api` on every loaded plugin and register its handle.
-    pub fn init_plugin_host_api(&self, api: crate::plugin::types::HostApiC) {
+    pub fn init_plugin_host_api(&self, api: *const crate::plugin::types::HostApiC) {
         let entries = match self.entries.read() {
             Ok(g) => g,
             Err(e) => {

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use super::loader::NativePlugin;
+use super::types::read_c_str;
 use super::types::{
     ContentProvider, Plugin, PluginError, PluginType, ShortcutProvider, ThemeProvider,
 };
@@ -10,6 +11,17 @@ use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::sync::{Mutex, OnceLock};
 
+/// Buffered plugin media source, drained by the main thread each frame.
+pub struct PendingMediaSource {
+    pub title: String,
+    pub artist: String,
+    pub album: String,
+    pub duration_ms: u64,
+    pub position_ms: u64,
+    pub is_playing: bool,
+    pub cover_data: Vec<u8>,
+}
+
 // ---------------------------------------------------------------------------
 // Global router — C callbacks route through thread-safe pending buffers
 // ---------------------------------------------------------------------------
@@ -17,6 +29,7 @@ use std::sync::{Mutex, OnceLock};
 static PENDING_CONTEXTS: OnceLock<Mutex<Vec<crate::core::context::PluginContext>>> =
     OnceLock::new();
 static PENDING_CLOSE: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+static PENDING_MEDIA_SOURCE: OnceLock<Mutex<Option<PendingMediaSource>>> = OnceLock::new();
 static PLUGIN_HANDLES: OnceLock<Mutex<HashMap<isize, String>>> = OnceLock::new();
 static HOST_STATE: OnceLock<Mutex<crate::plugin::types::HostState>> = OnceLock::new();
 
@@ -24,6 +37,7 @@ static HOST_STATE: OnceLock<Mutex<crate::plugin::types::HostState>> = OnceLock::
 pub fn init_host_api() -> crate::plugin::types::HostApiC {
     PENDING_CONTEXTS.get_or_init(|| Mutex::new(Vec::new()));
     PENDING_CLOSE.get_or_init(|| Mutex::new(Vec::new()));
+    PENDING_MEDIA_SOURCE.get_or_init(|| Mutex::new(None));
     PLUGIN_HANDLES.get_or_init(|| Mutex::new(HashMap::new()));
     HOST_STATE.get_or_init(|| Mutex::new(crate::plugin::types::HostState::default()));
 
@@ -31,6 +45,8 @@ pub fn init_host_api() -> crate::plugin::types::HostApiC {
         send_context: host_send_context,
         close_context: host_close_context,
         query_host_state: host_query_host_state,
+        set_media_source: host_set_media_source,
+        clear_media_source: host_clear_media_source,
     }
 }
 
@@ -80,6 +96,53 @@ pub fn update_host_state(state: crate::plugin::types::HostState) {
     {
         *m = state;
     }
+}
+
+/// Drain the pending plugin media source. Returns `None` if cleared or empty.
+pub fn drain_pending_media_source() -> Option<PendingMediaSource> {
+    PENDING_MEDIA_SOURCE.get()?.lock().ok()?.take()
+}
+
+unsafe extern "C" fn host_set_media_source(
+    _handle: crate::plugin::types::PluginHandle,
+    data: crate::plugin::types::MediaSourceC,
+) -> crate::plugin::types::PluginResultC {
+    let raw = read_c_str(&data.title);
+    if raw.is_empty() {
+        return crate::plugin::types::PluginResultC::err("title is empty");
+    }
+
+    let cover_data = if !data.cover_data.is_null() && data.cover_len > 0 {
+        unsafe { std::slice::from_raw_parts(data.cover_data, data.cover_len as usize) }.to_vec()
+    } else {
+        Vec::new()
+    };
+
+    if let Some(buf) = PENDING_MEDIA_SOURCE.get()
+        && let Ok(mut m) = buf.lock()
+    {
+        *m = Some(PendingMediaSource {
+            title: raw,
+            artist: read_c_str(&data.artist),
+            album: read_c_str(&data.album),
+            duration_ms: data.duration_ms,
+            position_ms: data.position_ms,
+            is_playing: data.is_playing,
+            cover_data,
+        });
+    }
+    crate::plugin::types::PluginResultC::ok()
+}
+
+unsafe extern "C" fn host_clear_media_source(
+    _handle: crate::plugin::types::PluginHandle,
+) -> crate::plugin::types::PluginResultC {
+    if let Some(buf) = PENDING_MEDIA_SOURCE.get()
+        && let Ok(mut m) = buf.lock()
+    {
+        *m = None;
+    }
+    crate::plugin::types::PluginResultC::ok()
 }
 
 unsafe extern "C" fn host_send_context(

--- a/src/plugin/types.rs
+++ b/src/plugin/types.rs
@@ -4,9 +4,10 @@ use serde::{Deserialize, Serialize};
 
 pub use winisland_plugin_api::{
     AnimationConfigC, ContextDataC, ContextIdC, HostApiC, HostStateC, ISLAND_CONTENT_TAG_MUSIC,
-    ISLAND_CONTENT_TAG_NOTIFICATION, ISLAND_CONTENT_TAG_STATUS, IslandContentC, PRIORITY_HIGH,
-    PRIORITY_LOW, PRIORITY_MEDIUM, PluginGetInstanceFn, PluginHandle, PluginInstanceC,
-    PluginMetadataC, PluginResultC, PluginType, PluginVTable, ShortcutC, ThemeColorsC,
+    ISLAND_CONTENT_TAG_NOTIFICATION, ISLAND_CONTENT_TAG_STATUS, IslandContentC, MediaSourceC,
+    PRIORITY_HIGH, PRIORITY_LOW, PRIORITY_MEDIUM, PluginGetInstanceFn, PluginHandle,
+    PluginInstanceC, PluginMetadataC, PluginResultC, PluginType, PluginVTable, ShortcutC,
+    ThemeColorsC,
 };
 
 pub fn read_c_str(buf: &[u8]) -> String {

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -94,6 +94,7 @@ pub struct App {
     touch_pos: PhysicalPosition<f64>,
     ctx_mgr: ContextManager,
     plugin_mgr: PluginManager,
+    plugin_media_source: Option<crate::core::smtc::MediaInfo>,
     pending_install: Option<mpsc::Receiver<InstallResult>>,
 }
 
@@ -155,6 +156,7 @@ impl Default for App {
             touch_pos: PhysicalPosition::new(0.0, 0.0),
             ctx_mgr: ContextManager::new(),
             plugin_mgr: PluginManager::default(),
+            plugin_media_source: None,
             pending_install: None,
         }
     }
@@ -1039,11 +1041,51 @@ impl ApplicationHandler for App {
                             - self.config.base_height * self.config.global_scale)
                             .abs();
                         let progress = (dist_h / total_h).clamp(0.0, 1.0);
-                        let mut media_info = if self.config.smtc_enabled {
-                            self.smtc.get_info()
-                        } else {
-                            crate::core::smtc::MediaInfo::default()
-                        };
+                        // Drain pending plugin media source (called once per frame)
+                        if let Some(ps) = crate::plugin::manager::drain_pending_media_source() {
+                            use std::sync::Arc;
+                            let (cover, hash) = if !ps.cover_data.is_empty() {
+                                use std::collections::hash_map::DefaultHasher;
+                                use std::hash::{Hash, Hasher};
+                                let mut hasher = DefaultHasher::new();
+                                ps.cover_data.hash(&mut hasher);
+                                (Some(Arc::new(ps.cover_data)), hasher.finish())
+                            } else {
+                                (None, 0)
+                            };
+                            self.plugin_media_source = Some(crate::core::smtc::MediaInfo {
+                                title: ps.title,
+                                artist: ps.artist,
+                                album: ps.album,
+                                duration_ms: ps.duration_ms,
+                                duration_secs: ps.duration_ms / 1000,
+                                position_ms: ps.position_ms,
+                                is_playing: ps.is_playing,
+                                last_update: Instant::now(),
+                                thumbnail: cover,
+                                thumbnail_hash: hash,
+                                ..Default::default()
+                            });
+                        }
+                        // Advance plugin media source position
+                        if let Some(ref mut info) = self.plugin_media_source
+                            && info.is_playing
+                        {
+                            let elapsed = info.last_update.elapsed().as_millis() as u64;
+                            info.position_ms = info.position_ms.saturating_add(elapsed);
+                            info.last_update = Instant::now();
+                        }
+                        let mut media_info = self
+                            .plugin_media_source
+                            .clone()
+                            .or_else(|| {
+                                if self.config.smtc_enabled {
+                                    Some(self.smtc.get_info())
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or_default();
                         if self.seeking_progress && self.seeking_duration_ms > 0 {
                             media_info.position_ms = self.seeking_preview_ms;
                             media_info.last_update = Instant::now();


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `CONTRIBUTING.md` 并完成要求测试
- [x] 本地/CI 测试通过（cargo check + clippy + fmt 零错误零警告）
- [x] 代码审查 (Self-review) 完成

## pr方向 (一定要选其中一个)

- [x] `feat` 新功能

## 影响范围（可多选）
- [x] 程序核心 Core
    - [ ] UI 样式/布局
    - [x] 功能逻辑
    - [ ] 其他

- [x] 后端 Backend
    - [x] 插件 API 接口变更

## 关联 Issue

无

## pr内容

### 摘要

插件可通过 `HostApiC.set_media_source` 注入完整的媒体源数据（标题、艺人、专辑、进度条、封面），宿主自动优先使用插件数据替代 SMTC，渲染管线零改动。

### 动机/背景

在前序 PR（`feat/plugin-content-rendering`）实现了插件向 Dynamic Island push context 的基础上，插件只能显示文字内容，无法参与媒体 UI（进度条、封面、歌词视图）的渲染。本次 PR 让插件可以**完全接管媒体源**，注入任意 title/artist/album/progress/cover，宿主自动用插件数据渲染现有音乐视图。

### 具体改动

**API 层（`winisland-plugin-api`）**

```rust
#[repr(C)]
pub struct MediaSourceC {
    pub title: [u8; 256],       // 歌曲标题
    pub artist: [u8; 256],      // 艺人
    pub album: [u8; 256],       // 专辑
    pub duration_ms: u64,       // 总时长（ms）
    pub position_ms: u64,       // 当前进度（ms）
    pub is_playing: bool,       // 是否正在播放
    pub cover_data: *const u8,  // 封面图原始字节指针（JPEG/PNG）
    pub cover_len: u32,         // 封面字节长度
}

// HostApiC 新增：
pub set_media_source:    fn(PluginHandle, MediaSourceC) -> PluginResultC,
pub clear_media_source:  fn(PluginHandle) -> PluginResultC,
```

**宿主侧**

| 模块 | 改动 |
|------|------|
| `src/plugin/manager.rs` | 新增 `PendingMediaSource`、`PENDING_MEDIA_SOURCE` pending buffer、`host_set_media_source`/`host_clear_media_source` FFI 回调、`drain_pending_media_source()` |
| `src/window/app.rs` | 新增 `plugin_media_source: Option<MediaInfo>`，每帧 drain pending buffer → 解析封面 hash + extrapolate 进度 → 优先于 SMTC |

**数据流**

```
插件 DLL（任意线程）
  └─ HostApiC.set_media_source(MediaSourceC { ... })

WinIsland 主线程（每帧）
  about_to_wait:
    ├─ drain_pending_media_source() → MediaInfo
    ├─ extrapolate position（is_playing 时自动推进进度条）
    ├─ self.plugin_media_source ?= Some : smtc.get_info()
    └─ render(media_info)  ← 复用现有音乐视图

插件调 clear_media_source() → plugin_media_source = None → 自动回退 SMTC
```

### 界面变动
无。所有新增数据流进入现有渲染管线，progress bar、cover art、lyrics view 等保持不变。