### PR TITLE
feat: add dual-task (multitask) mode

### DIFF
--- a/src/core/context/mod.rs
+++ b/src/core/context/mod.rs
@@ -86,6 +86,23 @@ impl ContextManager {
         None
     }
 
+    /// 返回所有可显示在 mini 的插件上下文（按优先级与时间倒序）
+    pub fn mini_candidates(&self) -> Vec<PluginContext> {
+        let mut candidates: Vec<_> = self
+            .plugin_contexts
+            .iter()
+            .filter(|context| context.mini_render)
+            .cloned()
+            .collect();
+        candidates.sort_by(|left, right| {
+            right
+                .priority
+                .cmp(&left.priority)
+                .then_with(|| right.created_at.cmp(&left.created_at))
+        });
+        candidates
+    }
+
     pub fn tick(&mut self) {
         let now = Instant::now();
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod context;
 pub mod i18n;
 pub mod lyrics;
+pub mod multitask;
 pub mod persistence;
 pub mod render;
 pub mod smtc;

--- a/src/core/multitask.rs
+++ b/src/core/multitask.rs
@@ -1,0 +1,656 @@
+use std::time::{Duration, Instant};
+
+use crate::core::context::{ContextId, MiniContent, Priority};
+
+pub const SPLIT_DURATION: Duration = Duration::from_millis(280);
+pub const MERGE_DURATION: Duration = Duration::from_millis(240);
+pub const REPLACE_DURATION: Duration = Duration::from_millis(200);
+pub const SWAP_DURATION: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MultitaskTaskId {
+    Music,
+    Plugin(ContextId),
+}
+
+#[derive(Debug, Clone)]
+pub struct MultitaskTask {
+    pub id: MultitaskTaskId,
+    pub content: MiniContent,
+    pub priority: Priority,
+    pub created_at: Instant,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MultitaskTransitionKind {
+    Stable,
+    Split,
+    Merge,
+    Promote,
+    Replace,
+    Swap,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct MultitaskFrame {
+    pub kind: MultitaskTransitionKind,
+    pub main_width_scale: f32,
+    pub main_radius_scale: f32,
+    pub main_offset_units: f32,
+    pub main_alpha: f32,
+    pub secondary_scale: f32,
+    pub secondary_alpha: f32,
+    pub secondary_content_alpha: f32,
+    pub secondary_slide_units: f32,
+    pub outgoing_secondary_scale: f32,
+    pub outgoing_secondary_alpha: f32,
+    pub gap_progress: f32,
+    pub bridge_progress: f32,
+    pub mask_alpha: f32,
+    pub breath_scale: f32,
+    pub promote_progress: f32,
+}
+
+impl Default for MultitaskFrame {
+    fn default() -> Self {
+        Self {
+            kind: MultitaskTransitionKind::Stable,
+            main_width_scale: 1.0,
+            main_radius_scale: 1.0,
+            main_offset_units: 0.0,
+            main_alpha: 1.0,
+            secondary_scale: 0.0,
+            secondary_alpha: 0.0,
+            secondary_content_alpha: 0.0,
+            secondary_slide_units: 0.0,
+            outgoing_secondary_scale: 0.0,
+            outgoing_secondary_alpha: 0.0,
+            gap_progress: 0.0,
+            bridge_progress: 0.0,
+            mask_alpha: 0.0,
+            breath_scale: 1.0,
+            promote_progress: 1.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+enum MultitaskTransition {
+    #[default]
+    Stable,
+    Split {
+        started_at: Instant,
+    },
+    Merge {
+        started_at: Instant,
+        outgoing: MultitaskTask,
+    },
+    Promote {
+        started_at: Instant,
+    },
+    Replace {
+        started_at: Instant,
+        outgoing: MultitaskTask,
+    },
+    Swap {
+        started_at: Instant,
+        old_primary: MultitaskTask,
+        old_secondary: MultitaskTask,
+    },
+}
+
+impl MultitaskTransition {
+    fn duration(&self) -> Duration {
+        match self {
+            Self::Stable => Duration::ZERO,
+            Self::Split { .. } => SPLIT_DURATION,
+            Self::Merge { .. } | Self::Promote { .. } => MERGE_DURATION,
+            Self::Replace { .. } => REPLACE_DURATION,
+            Self::Swap { .. } => SWAP_DURATION,
+        }
+    }
+
+    fn started_at(&self) -> Option<Instant> {
+        match self {
+            Self::Stable => None,
+            Self::Split { started_at }
+            | Self::Merge { started_at, .. }
+            | Self::Promote { started_at }
+            | Self::Replace { started_at, .. }
+            | Self::Swap { started_at, .. } => Some(*started_at),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct MultitaskController {
+    primary: Option<MultitaskTask>,
+    secondary: Option<MultitaskTask>,
+    transition: MultitaskTransition,
+}
+
+impl MultitaskController {
+    pub fn primary(&self) -> Option<&MultitaskTask> {
+        self.primary.as_ref()
+    }
+
+    pub fn secondary(&self) -> Option<&MultitaskTask> {
+        self.secondary.as_ref()
+    }
+
+    pub fn transition_kind(&self) -> MultitaskTransitionKind {
+        match self.transition {
+            MultitaskTransition::Stable => MultitaskTransitionKind::Stable,
+            MultitaskTransition::Split { .. } => MultitaskTransitionKind::Split,
+            MultitaskTransition::Merge { .. } => MultitaskTransitionKind::Merge,
+            MultitaskTransition::Promote { .. } => MultitaskTransitionKind::Promote,
+            MultitaskTransition::Replace { .. } => MultitaskTransitionKind::Replace,
+            MultitaskTransition::Swap { .. } => MultitaskTransitionKind::Swap,
+        }
+    }
+
+    pub fn is_animating(&self) -> bool {
+        !matches!(self.transition, MultitaskTransition::Stable)
+    }
+
+    pub fn reconcile(&mut self, candidates: &[MultitaskTask], now: Instant) {
+        self.finish_transition(now);
+        if self.is_animating() {
+            return;
+        }
+
+        let contains = |task: &MultitaskTask| candidates.iter().any(|item| item.id == task.id);
+        match (&self.primary, &self.secondary) {
+            (None, _) => {
+                self.primary = candidates.first().cloned();
+                self.secondary = None;
+            }
+            (Some(primary), Some(secondary)) if !contains(primary) => {
+                if contains(secondary) {
+                    self.primary = Some(secondary.clone());
+                    self.secondary = None;
+                    self.transition = MultitaskTransition::Promote { started_at: now };
+                } else {
+                    self.primary = candidates.first().cloned();
+                    self.secondary = None;
+                }
+            }
+            (Some(primary), Some(secondary)) if !contains(secondary) => {
+                let replacement = best_candidate(candidates, &[&primary.id]);
+                if let Some(replacement) = replacement {
+                    let outgoing = secondary.clone();
+                    self.secondary = Some(replacement);
+                    self.transition = MultitaskTransition::Replace {
+                        started_at: now,
+                        outgoing,
+                    };
+                } else {
+                    let outgoing = secondary.clone();
+                    self.secondary = None;
+                    self.transition = MultitaskTransition::Merge {
+                        started_at: now,
+                        outgoing,
+                    };
+                }
+            }
+            (Some(primary), Some(secondary)) => {
+                let incoming = best_candidate(candidates, &[&primary.id, &secondary.id]);
+                if let Some(incoming) = incoming
+                    && outranks(&incoming, secondary)
+                {
+                    let outgoing = secondary.clone();
+                    self.secondary = Some(incoming);
+                    self.transition = MultitaskTransition::Replace {
+                        started_at: now,
+                        outgoing,
+                    };
+                }
+            }
+            (Some(primary), None) if !contains(primary) => {
+                self.primary = candidates.first().cloned();
+            }
+            (Some(primary), None) => {
+                if let Some(secondary) = best_candidate(candidates, &[&primary.id]) {
+                    self.secondary = Some(secondary);
+                    self.transition = MultitaskTransition::Split { started_at: now };
+                }
+            }
+        }
+    }
+
+    pub fn swap(&mut self, now: Instant) -> bool {
+        self.finish_transition(now);
+        if self.is_animating() {
+            return false;
+        }
+        let (Some(primary), Some(secondary)) = (&self.primary, &self.secondary) else {
+            return false;
+        };
+        self.transition = MultitaskTransition::Swap {
+            started_at: now,
+            old_primary: primary.clone(),
+            old_secondary: secondary.clone(),
+        };
+        true
+    }
+
+    pub fn display_tasks(&self, now: Instant) -> (Option<MultitaskTask>, Option<MultitaskTask>) {
+        if let MultitaskTransition::Swap {
+            started_at,
+            old_primary,
+            old_secondary,
+        } = &self.transition
+        {
+            if elapsed_ms(now, *started_at) >= 100.0 {
+                return (Some(old_secondary.clone()), Some(old_primary.clone()));
+            }
+            return (Some(old_primary.clone()), Some(old_secondary.clone()));
+        }
+        (self.primary.clone(), self.secondary.clone())
+    }
+
+    pub fn outgoing_secondary(&self) -> Option<&MultitaskTask> {
+        match &self.transition {
+            MultitaskTransition::Merge { outgoing, .. }
+            | MultitaskTransition::Replace { outgoing, .. } => Some(outgoing),
+            _ => None,
+        }
+    }
+
+    pub fn frame(&self, now: Instant) -> MultitaskFrame {
+        match &self.transition {
+            MultitaskTransition::Stable => stable_frame(self.secondary.is_some()),
+            MultitaskTransition::Split { started_at } => split_frame(elapsed_ms(now, *started_at)),
+            MultitaskTransition::Merge { started_at, .. } => {
+                merge_frame(elapsed_ms(now, *started_at), false)
+            }
+            MultitaskTransition::Promote { started_at } => {
+                merge_frame(elapsed_ms(now, *started_at), true)
+            }
+            MultitaskTransition::Replace { started_at, .. } => {
+                replace_frame(elapsed_ms(now, *started_at))
+            }
+            MultitaskTransition::Swap { started_at, .. } => {
+                swap_frame(elapsed_ms(now, *started_at))
+            }
+        }
+    }
+
+    fn finish_transition(&mut self, now: Instant) {
+        let Some(started_at) = self.transition.started_at() else {
+            return;
+        };
+        if now.saturating_duration_since(started_at) < self.transition.duration() {
+            return;
+        }
+        if let MultitaskTransition::Swap {
+            old_primary,
+            old_secondary,
+            ..
+        } = &self.transition
+        {
+            self.primary = Some(old_secondary.clone());
+            self.secondary = Some(old_primary.clone());
+        }
+        self.transition = MultitaskTransition::Stable;
+    }
+}
+
+fn best_candidate(
+    candidates: &[MultitaskTask],
+    excluded: &[&MultitaskTaskId],
+) -> Option<MultitaskTask> {
+    candidates
+        .iter()
+        .find(|candidate| !excluded.contains(&&candidate.id))
+        .cloned()
+}
+
+fn outranks(incoming: &MultitaskTask, current: &MultitaskTask) -> bool {
+    incoming.priority > current.priority
+        || (incoming.priority == current.priority && incoming.created_at > current.created_at)
+}
+
+fn elapsed_ms(now: Instant, started_at: Instant) -> f32 {
+    now.saturating_duration_since(started_at).as_secs_f32() * 1000.0
+}
+
+fn unit(value: f32) -> f32 {
+    value.clamp(0.0, 1.0)
+}
+
+fn smooth(value: f32) -> f32 {
+    let value = unit(value);
+    value * value * (3.0 - 2.0 * value)
+}
+
+fn stable_frame(dual: bool) -> MultitaskFrame {
+    MultitaskFrame {
+        secondary_scale: if dual { 1.0 } else { 0.0 },
+        secondary_alpha: if dual { 1.0 } else { 0.0 },
+        secondary_content_alpha: if dual { 1.0 } else { 0.0 },
+        gap_progress: if dual { 1.0 } else { 0.0 },
+        ..Default::default()
+    }
+}
+
+fn split_frame(ms: f32) -> MultitaskFrame {
+    let mut frame = MultitaskFrame {
+        kind: MultitaskTransitionKind::Split,
+        bridge_progress: 1.0,
+        ..Default::default()
+    };
+    if ms < 50.0 {
+        let progress = smooth(ms / 50.0);
+        frame.main_width_scale = 1.0 + 0.06 * progress;
+        frame.main_radius_scale = 1.0 - 0.08 * progress;
+        frame.mask_alpha = 0.10 * progress;
+    } else if ms < 126.0 {
+        let progress = smooth((ms - 50.0) / 76.0);
+        frame.main_width_scale = 1.06 - 0.06 * progress;
+        frame.main_radius_scale = 0.92 + 0.04 * progress;
+        frame.main_offset_units = -4.0 * progress;
+        frame.gap_progress = progress;
+        frame.bridge_progress = 1.0 - progress;
+        frame.mask_alpha = 0.10 * (1.0 - progress * 0.65);
+        frame.secondary_scale = 1.0 - 0.28 * progress;
+        frame.secondary_alpha = progress;
+    } else if ms < 218.0 {
+        let progress = smooth((ms - 126.0) / 92.0);
+        frame.main_radius_scale = 0.96 + 0.04 * progress;
+        frame.main_offset_units = -4.0 * (1.0 - progress);
+        frame.secondary_scale = 0.72 + 0.28 * progress;
+        frame.secondary_alpha = 1.0;
+        frame.secondary_content_alpha = progress;
+        frame.gap_progress = 1.0;
+        frame.mask_alpha = 0.035 * (1.0 - progress);
+    } else {
+        let progress = unit((ms - 218.0) / 62.0);
+        let rebound = (std::f32::consts::PI * progress).sin() * (1.0 - progress);
+        frame.secondary_scale = 1.0 + 0.05 * rebound;
+        frame.secondary_alpha = 1.0;
+        frame.secondary_content_alpha = 1.0;
+        frame.secondary_slide_units = -3.0 * rebound;
+        frame.gap_progress = 1.0;
+    }
+    frame
+}
+
+fn merge_frame(ms: f32, promote: bool) -> MultitaskFrame {
+    let mut frame = MultitaskFrame {
+        kind: if promote {
+            MultitaskTransitionKind::Promote
+        } else {
+            MultitaskTransitionKind::Merge
+        },
+        secondary_scale: 1.0,
+        secondary_alpha: 1.0,
+        secondary_content_alpha: 1.0,
+        outgoing_secondary_scale: 1.0,
+        outgoing_secondary_alpha: 1.0,
+        gap_progress: 1.0,
+        promote_progress: if promote { 0.0 } else { 1.0 },
+        ..Default::default()
+    };
+    if ms < 70.0 {
+        let progress = smooth(ms / 70.0);
+        frame.outgoing_secondary_scale = 1.0 - 0.65 * progress;
+        frame.outgoing_secondary_alpha = 1.0 - progress;
+        frame.secondary_scale = frame.outgoing_secondary_scale;
+        frame.secondary_alpha = frame.outgoing_secondary_alpha;
+        frame.secondary_content_alpha = frame.secondary_alpha;
+        frame.main_alpha = if promote { 0.0 } else { 1.0 };
+    } else if ms < 156.0 {
+        let progress = smooth((ms - 70.0) / 86.0);
+        frame.secondary_scale = 0.0;
+        frame.secondary_alpha = 0.0;
+        frame.outgoing_secondary_scale = 0.35 * (1.0 - progress);
+        frame.outgoing_secondary_alpha = 0.0;
+        frame.gap_progress = 1.0 - progress;
+        frame.bridge_progress = progress * (1.0 - progress);
+        frame.mask_alpha = 0.10 * (1.0 - progress);
+        frame.promote_progress = if promote { progress } else { 1.0 };
+        frame.main_alpha = if promote { progress } else { 1.0 };
+    } else {
+        let progress = unit((ms - 156.0) / 84.0);
+        frame.secondary_scale = 0.0;
+        frame.secondary_alpha = 0.0;
+        frame.gap_progress = 0.0;
+        frame.promote_progress = 1.0;
+        frame.main_alpha = 1.0;
+        frame.breath_scale = 1.0 + 0.025 * (std::f32::consts::PI * progress).sin();
+    }
+    frame
+}
+
+fn replace_frame(ms: f32) -> MultitaskFrame {
+    let outgoing_progress = smooth(ms / 80.0);
+    let incoming_progress = smooth((ms - 60.0) / 140.0);
+    let mut outgoing_alpha = 1.0 - outgoing_progress;
+    let mut incoming_alpha = incoming_progress;
+    let sum = outgoing_alpha + incoming_alpha;
+    if sum > 1.0 {
+        outgoing_alpha /= sum;
+        incoming_alpha /= sum;
+    }
+    MultitaskFrame {
+        kind: MultitaskTransitionKind::Replace,
+        secondary_scale: 0.72 + 0.28 * incoming_progress,
+        secondary_alpha: incoming_alpha,
+        secondary_content_alpha: incoming_alpha,
+        secondary_slide_units: 10.0 * (1.0 - incoming_progress),
+        outgoing_secondary_scale: 1.0 - 0.40 * outgoing_progress,
+        outgoing_secondary_alpha: outgoing_alpha,
+        gap_progress: 1.0,
+        ..Default::default()
+    }
+}
+
+fn swap_frame(ms: f32) -> MultitaskFrame {
+    let first_half = ms < 100.0;
+    let progress = if first_half {
+        smooth(ms / 100.0)
+    } else {
+        smooth((ms - 100.0) / 100.0)
+    };
+    let alpha = if first_half { 1.0 - progress } else { progress };
+    let scale = if first_half {
+        1.0 - 0.12 * progress
+    } else {
+        0.88 + 0.12 * progress
+    };
+    MultitaskFrame {
+        kind: MultitaskTransitionKind::Swap,
+        main_alpha: alpha,
+        secondary_scale: scale,
+        secondary_alpha: alpha,
+        secondary_content_alpha: alpha,
+        gap_progress: 1.0,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::context::PluginContext;
+
+    fn task(source: &str, priority: Priority, created_at: Instant) -> MultitaskTask {
+        let context = PluginContext {
+            id: ContextId::new(source),
+            priority,
+            title: source.to_string(),
+            body: String::new(),
+            icon: Vec::new(),
+            duration_sec: 10,
+            mini_render: true,
+            mini_text: source.to_string(),
+            created_at,
+            expanded_started_at: None,
+            collapsed_at: None,
+            mini_timeout_start: None,
+        };
+        MultitaskTask {
+            id: MultitaskTaskId::Plugin(context.id.clone()),
+            content: MiniContent::Plugin(Box::new(context)),
+            priority,
+            created_at,
+        }
+    }
+
+    #[test]
+    fn split_preserves_existing_primary() {
+        let now = Instant::now();
+        let first = task("first", Priority::Low, now);
+        let second = task("second", Priority::High, now + Duration::from_millis(1));
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), now);
+        controller.reconcile(&[second.clone(), first.clone()], now);
+        assert_eq!(controller.primary().map(|item| &item.id), Some(&first.id));
+        assert_eq!(
+            controller.secondary().map(|item| &item.id),
+            Some(&second.id)
+        );
+        assert_eq!(controller.transition_kind(), MultitaskTransitionKind::Split);
+    }
+
+    #[test]
+    fn higher_or_newer_third_task_replaces_secondary() {
+        let now = Instant::now();
+        let first = task("first", Priority::Low, now);
+        let second = task("second", Priority::Medium, now + Duration::from_millis(1));
+        let third = task("third", Priority::High, now + Duration::from_millis(2));
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), now);
+        controller.reconcile(&[second.clone(), first.clone()], now);
+        controller.reconcile(&[third.clone(), second, first], now + SPLIT_DURATION);
+        assert_eq!(controller.secondary().map(|item| &item.id), Some(&third.id));
+        assert_eq!(
+            controller.transition_kind(),
+            MultitaskTransitionKind::Replace
+        );
+    }
+
+    #[test]
+    fn lower_priority_third_task_does_not_replace_secondary() {
+        let now = Instant::now();
+        let first = task("first", Priority::Low, now);
+        let second = task("second", Priority::High, now + Duration::from_millis(1));
+        let third = task("third", Priority::Medium, now + Duration::from_millis(2));
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), now);
+        controller.reconcile(&[second.clone(), first.clone()], now);
+        controller.reconcile(&[second.clone(), third, first], now + SPLIT_DURATION);
+        assert_eq!(
+            controller.secondary().map(|item| &item.id),
+            Some(&second.id)
+        );
+        assert_eq!(
+            controller.transition_kind(),
+            MultitaskTransitionKind::Stable
+        );
+    }
+
+    #[test]
+    fn newer_equal_priority_task_replaces_secondary() {
+        let now = Instant::now();
+        let first = task("first", Priority::Low, now);
+        let second = task("second", Priority::High, now + Duration::from_millis(1));
+        let third = task("third", Priority::High, now + Duration::from_millis(2));
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), now);
+        controller.reconcile(&[second.clone(), first.clone()], now);
+        controller.reconcile(&[third.clone(), second, first], now + SPLIT_DURATION);
+        assert_eq!(controller.secondary().map(|item| &item.id), Some(&third.id));
+        assert_eq!(
+            controller.transition_kind(),
+            MultitaskTransitionKind::Replace
+        );
+    }
+
+    #[test]
+    fn ending_secondary_merges_to_single_task() {
+        let now = Instant::now();
+        let first = task("first", Priority::Low, now);
+        let second = task("second", Priority::High, now + Duration::from_millis(1));
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), now);
+        controller.reconcile(&[second, first.clone()], now);
+        controller.reconcile(std::slice::from_ref(&first), now + SPLIT_DURATION);
+        assert_eq!(controller.transition_kind(), MultitaskTransitionKind::Merge);
+        assert!(controller.secondary().is_none());
+        assert!(controller.outgoing_secondary().is_some());
+    }
+
+    #[test]
+    fn ending_primary_promotes_secondary() {
+        let now = Instant::now();
+        let first = task("first", Priority::Low, now);
+        let second = task("second", Priority::High, now + Duration::from_millis(1));
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), now);
+        controller.reconcile(&[second.clone(), first], now);
+        controller.reconcile(std::slice::from_ref(&second), now + SPLIT_DURATION);
+        assert_eq!(
+            controller.transition_kind(),
+            MultitaskTransitionKind::Promote
+        );
+        assert_eq!(controller.primary().map(|item| &item.id), Some(&second.id));
+        assert!(controller.secondary().is_none());
+    }
+
+    #[test]
+    fn task_change_during_split_is_reconciled_after_split() {
+        let now = Instant::now();
+        let first = task("first", Priority::Low, now);
+        let second = task("second", Priority::Medium, now + Duration::from_millis(1));
+        let third = task("third", Priority::High, now + Duration::from_millis(2));
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), now);
+        controller.reconcile(&[second.clone(), first.clone()], now);
+        controller.reconcile(
+            &[third.clone(), second.clone(), first.clone()],
+            now + Duration::from_millis(100),
+        );
+        assert_eq!(
+            controller.secondary().map(|item| &item.id),
+            Some(&second.id)
+        );
+        controller.reconcile(&[third.clone(), second, first], now + SPLIT_DURATION);
+        assert_eq!(controller.secondary().map(|item| &item.id), Some(&third.id));
+        assert_eq!(
+            controller.transition_kind(),
+            MultitaskTransitionKind::Replace
+        );
+    }
+
+    #[test]
+    fn replacement_frame_never_moves_main_or_exceeds_total_alpha() {
+        for ms in [0, 60, 80, 100, 200] {
+            let frame = replace_frame(ms as f32);
+            assert_eq!(frame.main_width_scale, 1.0);
+            assert_eq!(frame.main_radius_scale, 1.0);
+            assert_eq!(frame.main_offset_units, 0.0);
+            assert!(frame.secondary_alpha + frame.outgoing_secondary_alpha <= 1.001);
+        }
+    }
+
+    #[test]
+    fn split_and_merge_frames_hit_required_keyframes() {
+        let split_start = Instant::now();
+        let first = task("first", Priority::Low, split_start);
+        let second = task("second", Priority::High, split_start);
+        let mut controller = MultitaskController::default();
+        controller.reconcile(std::slice::from_ref(&first), split_start);
+        controller.reconcile(&[second.clone(), first.clone()], split_start);
+        let pre = controller.frame(split_start + Duration::from_millis(50));
+        let shaped = controller.frame(split_start + Duration::from_millis(218));
+        assert!((pre.main_width_scale - 1.06).abs() < 0.001);
+        assert_eq!(shaped.gap_progress, 1.0);
+
+        controller.reconcile(std::slice::from_ref(&first), split_start + SPLIT_DURATION);
+        let merged = controller.frame(split_start + SPLIT_DURATION + MERGE_DURATION);
+        assert!(merged.secondary_alpha <= 0.001);
+        assert!((merged.breath_scale - 1.0).abs() < 0.001);
+    }
+}

--- a/src/core/render.rs
+++ b/src/core/render.rs
@@ -10,8 +10,8 @@ use crate::utils::font::{DrawTextCachedParams, FontManager};
 use crate::utils::glass::get_glass_background;
 use skia_safe::canvas::SrcRectConstraint;
 use skia_safe::{
-    ClipOp, Color, FilterMode, ISize, MipmapMode, Paint, RRect, Rect, SamplingOptions,
-    Surface as SkSurface, image_filters, surfaces,
+    ClipOp, Color, Data, FilterMode, Image, ISize, MipmapMode, Paint, PathBuilder, RRect, Rect,
+    SamplingOptions, Surface as SkSurface, image_filters, surfaces,
 };
 use softbuffer::Surface;
 use std::cell::RefCell;
@@ -74,15 +74,428 @@ pub struct StyleParams<'a> {
     pub dt: f32,
 }
 
-use crate::core::context::MiniContent;
+use crate::core::context::{MiniContent, PluginContext};
+use crate::core::multitask::{MultitaskFrame, MultitaskTransitionKind};
 
 pub struct DrawIslandParams<'a> {
     pub layout: LayoutParams,
     pub media: MediaParams<'a>,
     pub lyrics: LyricsParams<'a>,
     pub mini_content: Option<MiniContent>,
+    pub secondary_mini_content: Option<MiniContent>,
+    pub outgoing_secondary_mini_content: Option<MiniContent>,
+    pub multitask_frame: MultitaskFrame,
+    pub multitask_hover_progress: f32,
     pub window: WindowParams,
     pub style: StyleParams<'a>,
+}
+
+#[derive(Clone, Copy)]
+pub struct MultitaskGroupLayoutParams {
+    pub base_h: f32,
+    pub global_scale: f32,
+    pub dock_position: DockPosition,
+    pub frame: MultitaskFrame,
+    pub hover_progress: f32,
+}
+
+pub fn get_multitask_group_shift(params: MultitaskGroupLayoutParams) -> f32 {
+    if params.dock_position.is_left() || params.dock_position.is_right() {
+        return 0.0;
+    }
+    let frame = params.frame;
+    let occupancy = match frame.kind {
+        MultitaskTransitionKind::Split => frame.secondary_scale * frame.secondary_alpha,
+        MultitaskTransitionKind::Merge => {
+            frame.outgoing_secondary_scale * frame.outgoing_secondary_alpha
+        }
+        MultitaskTransitionKind::Promote => 0.0,
+        MultitaskTransitionKind::Replace | MultitaskTransitionKind::Swap => 1.0,
+        MultitaskTransitionKind::Stable => {
+            frame.secondary_scale.max(frame.outgoing_secondary_scale)
+        }
+    }
+    .clamp(0.0, 1.0);
+    if occupancy <= 0.0 {
+        return 0.0;
+    }
+    let hover_scale = 1.0 + params.hover_progress.clamp(0.0, 1.0) * 0.06;
+    let diameter = params.base_h.max(27.0 * params.global_scale) * occupancy * hover_scale;
+    let gap = 7.0 * params.global_scale * frame.gap_progress * occupancy;
+    -(diameter + gap) / 2.0
+}
+
+pub struct MultitaskLayoutParams {
+    pub offset_x: f32,
+    pub offset_y: f32,
+    pub current_w: f32,
+    pub current_h: f32,
+    pub base_h: f32,
+    pub global_scale: f32,
+    pub dock_position: DockPosition,
+    pub frame: MultitaskFrame,
+    pub hover_progress: f32,
+}
+
+pub fn get_multitask_secondary_rect(params: MultitaskLayoutParams) -> (f32, f32, f32, f32) {
+    let MultitaskLayoutParams {
+        offset_x,
+        offset_y,
+        current_w,
+        current_h,
+        base_h,
+        global_scale,
+        dock_position,
+        frame,
+        hover_progress,
+    } = params;
+    let hover_progress = hover_progress.clamp(0.0, 1.0);
+    let task_scale = frame
+        .secondary_scale
+        .max(frame.outgoing_secondary_scale)
+        .clamp(0.0, 1.08);
+    let scale = task_scale * (1.0 + hover_progress * 0.06);
+    let diameter = base_h.max(27.0 * global_scale) * scale;
+    let width = diameter;
+    let height = diameter;
+    let gap = 7.0 * global_scale * frame.gap_progress;
+    let center_y = offset_y + current_h / 2.0;
+    let y = center_y - height / 2.0;
+    let main_right = offset_x + current_w;
+    let slide = frame.secondary_slide_units * global_scale;
+    let x = if dock_position.is_right() {
+        offset_x - gap - width - slide
+    } else {
+        main_right + gap + slide
+    };
+    (x, y, width, height)
+}
+
+struct MultitaskSecondaryParams<'a> {
+    content: Option<&'a MiniContent>,
+    outgoing_content: Option<&'a MiniContent>,
+    media: &'a MediaInfo,
+    offset_x: f32,
+    offset_y: f32,
+    current_w: f32,
+    current_h: f32,
+    base_h: f32,
+    global_scale: f32,
+    dock_position: DockPosition,
+    frame: MultitaskFrame,
+    hover_progress: f32,
+}
+
+fn draw_multitask_secondary(canvas: &skia_safe::Canvas, params: MultitaskSecondaryParams<'_>) {
+    let MultitaskSecondaryParams {
+        content,
+        outgoing_content,
+        media,
+        offset_x,
+        offset_y,
+        current_w,
+        current_h,
+        base_h,
+        global_scale,
+        dock_position,
+        frame,
+        hover_progress,
+    } = params;
+    if frame.secondary_alpha <= 0.01 && frame.outgoing_secondary_alpha <= 0.01 {
+        return;
+    }
+    if let Some(outgoing) = outgoing_content {
+        let outgoing_frame = MultitaskFrame {
+            secondary_scale: frame.outgoing_secondary_scale,
+            secondary_alpha: frame.outgoing_secondary_alpha,
+            secondary_content_alpha: frame.outgoing_secondary_alpha,
+            secondary_slide_units: 0.0,
+            ..frame
+        };
+        draw_secondary_task(
+            canvas,
+            outgoing,
+            media,
+            MultitaskLayoutParams {
+                offset_x,
+                offset_y,
+                current_w,
+                current_h,
+                base_h,
+                global_scale,
+                dock_position,
+                frame: outgoing_frame,
+                hover_progress: 0.0,
+            },
+        );
+    }
+    if let Some(content) = content {
+        draw_secondary_task(
+            canvas,
+            content,
+            media,
+            MultitaskLayoutParams {
+                offset_x,
+                offset_y,
+                current_w,
+                current_h,
+                base_h,
+                global_scale,
+                dock_position,
+                frame,
+                hover_progress,
+            },
+        );
+    }
+}
+
+fn draw_secondary_task(
+    canvas: &skia_safe::Canvas,
+    content: &MiniContent,
+    media: &MediaInfo,
+    params: MultitaskLayoutParams,
+) {
+    let global_scale = params.global_scale;
+    let dock_position = params.dock_position;
+    let alpha_f = params.frame.secondary_alpha.clamp(0.0, 1.0);
+    let content_alpha_f = (alpha_f * params.frame.secondary_content_alpha).clamp(0.0, 1.0);
+    let (x, y, w, h) = get_multitask_secondary_rect(params);
+    if w <= 0.1 || alpha_f <= 0.01 {
+        return;
+    }
+    let alpha = (alpha_f * 255.0) as u8;
+    let content_alpha = (content_alpha_f * 255.0) as u8;
+    let center = (x + w / 2.0, y + h / 2.0);
+    let radius = w / 2.0;
+
+    let mut shadow_paint = Paint::default();
+    shadow_paint.set_anti_alias(true);
+    shadow_paint.set_color(Color::from_argb((alpha_f * 75.0) as u8, 0, 0, 0));
+    shadow_paint.set_image_filter(image_filters::blur(
+        (5.0 * global_scale, 5.0 * global_scale),
+        None,
+        None,
+        None,
+    ));
+    let shadow_margin = 8.0 * global_scale;
+    let shadow_clip = if dock_position.is_right() {
+        Rect::from_xywh(
+            x - shadow_margin,
+            y - shadow_margin,
+            w + shadow_margin,
+            h + shadow_margin * 2.0,
+        )
+    } else {
+        Rect::from_xywh(
+            x,
+            y - shadow_margin,
+            w + shadow_margin,
+            h + shadow_margin * 2.0,
+        )
+    };
+    canvas.save();
+    canvas.clip_rect(shadow_clip, ClipOp::Intersect, true);
+    canvas.draw_circle((center.0, center.1 + 2.0 * global_scale), radius, &shadow_paint);
+    canvas.restore();
+
+    canvas.save();
+    canvas.clip_rrect(
+        RRect::new_rect_xy(Rect::from_xywh(x, y, w, h), radius, radius),
+        ClipOp::Intersect,
+        true,
+    );
+    let mut background_paint = Paint::default();
+    background_paint.set_anti_alias(true);
+    background_paint.set_color(Color::from_argb(alpha, 7, 7, 9));
+    canvas.draw_circle(center, radius, &background_paint);
+
+    let icon_size = h * 0.68;
+    let icon_rect = Rect::from_xywh(
+        center.0 - icon_size / 2.0,
+        center.1 - icon_size / 2.0,
+        icon_size,
+        icon_size,
+    );
+    match content {
+        MiniContent::Plugin(ctx) => {
+            if let Some(icon) = notification_icon(ctx) {
+                let mut icon_paint = Paint::default();
+                icon_paint.set_anti_alias(true);
+                icon_paint.set_alpha_f(content_alpha_f);
+                canvas.save();
+                canvas.clip_rrect(
+                    RRect::new_rect_xy(icon_rect, icon_size * 0.24, icon_size * 0.24),
+                    ClipOp::Intersect,
+                    true,
+                );
+                canvas.draw_image_rect_with_sampling_options(
+                    &icon,
+                    None,
+                    icon_rect,
+                    SamplingOptions::new(FilterMode::Linear, MipmapMode::Linear),
+                    &icon_paint,
+                );
+                canvas.restore();
+            } else {
+                let mut icon_paint = Paint::default();
+                icon_paint.set_anti_alias(true);
+                icon_paint.set_color(Color::from_argb(content_alpha, 93, 92, 222));
+                canvas.draw_circle(
+                    (icon_rect.center_x(), icon_rect.center_y()),
+                    icon_size / 2.0,
+                    &icon_paint,
+                );
+                let label = ctx
+                    .title
+                    .chars()
+                    .next()
+                    .map(|character| character.to_string())
+                    .unwrap_or_else(|| "?".to_string());
+                let size = icon_size * 0.54;
+                let label_w = FontManager::global()
+                    .measure_text_cached(&label, size, skia_safe::FontStyle::bold());
+                let mut label_paint = Paint::default();
+                label_paint.set_anti_alias(true);
+                label_paint.set_color(Color::from_argb(content_alpha, 255, 255, 255));
+                draw_text_cached(DrawTextCachedParams {
+                    canvas,
+                    text: &label,
+                    x: icon_rect.center_x() - label_w / 2.0,
+                    y: icon_rect.center_y() + size * 0.35,
+                    size,
+                    bold: true,
+                    paint: &label_paint,
+                });
+            }
+        }
+        MiniContent::Music => {
+            if let Some(image) = get_cached_media_image(media) {
+                let mut image_paint = Paint::default();
+                image_paint.set_anti_alias(true);
+                image_paint.set_alpha_f(content_alpha_f);
+                canvas.save();
+                canvas.clip_rrect(
+                    RRect::new_rect_xy(icon_rect, icon_size * 0.24, icon_size * 0.24),
+                    ClipOp::Intersect,
+                    true,
+                );
+                canvas.draw_image_rect_with_sampling_options(
+                    &image,
+                    None,
+                    icon_rect,
+                    SamplingOptions::new(FilterMode::Linear, MipmapMode::Linear),
+                    &image_paint,
+                );
+                canvas.restore();
+            } else {
+                let palette = get_media_palette(media);
+                draw_visualizer(DrawVisualizerParams {
+                    canvas,
+                    x: icon_rect.center_x(),
+                    y: icon_rect.center_y(),
+                    alpha: content_alpha,
+                    is_playing: media.is_playing,
+                    palette: &palette,
+                    spectrum: &media.spectrum,
+                    w_scale: 0.55 * global_scale,
+                    h_scale: 0.55 * global_scale,
+                    smooth_factors: (0.6, 0.08),
+                });
+            }
+        }
+    }
+    canvas.restore();
+}
+
+fn draw_multitask_bridge(canvas: &skia_safe::Canvas, params: MultitaskLayoutParams) {
+    let MultitaskLayoutParams {
+        offset_x,
+        offset_y,
+        current_w,
+        current_h,
+        base_h,
+        global_scale,
+        dock_position,
+        frame,
+        hover_progress: _,
+    } = params;
+    let strength = frame.bridge_progress.max(frame.mask_alpha * 4.0);
+    if strength <= 0.01 {
+        return;
+    }
+    let diameter = base_h.max(27.0 * global_scale);
+    let radius = diameter / 2.0;
+    let center_y = offset_y + current_h / 2.0;
+    let gap = 7.0 * global_scale * frame.gap_progress;
+    let main_edge = if dock_position.is_right() {
+        offset_x
+    } else {
+        offset_x + current_w
+    };
+    let secondary_center = if dock_position.is_right() {
+        main_edge - gap - radius
+    } else {
+        main_edge + gap + radius
+    };
+    let direction = if dock_position.is_right() { -1.0 } else { 1.0 };
+    let secondary_edge = secondary_center - direction * radius;
+    let neck = radius * (0.18 + 0.34 * strength);
+    let shoulder = current_h * (0.20 + 0.12 * strength);
+    let mut path = PathBuilder::new();
+    path.move_to((main_edge, center_y - shoulder));
+    path.cubic_to(
+        (
+            main_edge + direction * radius * 0.35,
+            center_y - shoulder,
+        ),
+        (
+            secondary_edge - direction * radius * 0.35,
+            center_y - neck,
+        ),
+        (secondary_edge, center_y - neck),
+    );
+    path.line_to((secondary_edge, center_y + neck));
+    path.cubic_to(
+        (
+            secondary_edge - direction * radius * 0.35,
+            center_y + neck,
+        ),
+        (
+            main_edge + direction * radius * 0.35,
+            center_y + shoulder,
+        ),
+        (main_edge, center_y + shoulder),
+    );
+    path.close();
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    let alpha = ((frame.mask_alpha + frame.bridge_progress * 0.08).clamp(0.0, 0.12) * 255.0) as u8;
+    paint.set_color(Color::from_argb(alpha, 0, 0, 0));
+    canvas.draw_path(&path.snapshot(), &paint);
+}
+
+thread_local! {
+    static SECONDARY_ICON_CACHE: RefCell<Option<(String, Image)>> = const { RefCell::new(None) };
+}
+
+fn notification_icon(ctx: &PluginContext) -> Option<Image> {
+    let cache_id = ctx.id.uuid.clone();
+    let bytes = ctx.icon.as_slice();
+    if bytes.is_empty() {
+        return None;
+    }
+    SECONDARY_ICON_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if let Some((id, image)) = cache.as_ref()
+            && id == &cache_id
+        {
+            return Some(image.clone());
+        }
+        let image = Image::from_encoded(Data::new_copy(bytes))?;
+        *cache = Some((cache_id, image.clone()));
+        Some(image)
+    })
 }
 
 pub fn draw_island(
@@ -94,6 +507,10 @@ pub fn draw_island(
         media,
         lyrics,
         mini_content,
+        secondary_mini_content,
+        outgoing_secondary_mini_content,
+        multitask_frame,
+        multitask_hover_progress,
         window,
         style,
     } = params;
@@ -112,6 +529,37 @@ pub fn draw_island(
         dock_position,
         base_h,
     } = layout;
+    let compact_animation = (1.0 - expansion_progress * 2.0).clamp(0.0, 1.0);
+    let width_scale = 1.0
+        + (multitask_frame.main_width_scale * multitask_frame.breath_scale - 1.0)
+            * compact_animation;
+    let radius_scale = 1.0
+        + (multitask_frame.main_radius_scale * multitask_frame.breath_scale - 1.0)
+            * compact_animation;
+    let promote_progress = if multitask_frame.kind == MultitaskTransitionKind::Promote {
+        multitask_frame.promote_progress * compact_animation + (1.0 - compact_animation)
+    } else {
+        1.0
+    };
+    let compact_diameter = base_h.max(27.0 * global_scale);
+    let target_w = current_w;
+    let target_h = current_h;
+    let target_r = current_r;
+    let current_w = if promote_progress < 1.0 {
+        compact_diameter + (target_w * width_scale - compact_diameter) * promote_progress
+    } else {
+        target_w * width_scale
+    };
+    let current_h = if promote_progress < 1.0 {
+        compact_diameter + (target_h - compact_diameter) * promote_progress
+    } else {
+        target_h * (1.0 + (multitask_frame.breath_scale - 1.0) * compact_animation)
+    };
+    let current_r = if promote_progress < 1.0 {
+        compact_diameter / 2.0 + (target_r * radius_scale - compact_diameter / 2.0) * promote_progress
+    } else {
+        target_r * radius_scale
+    };
     let MediaParams {
         media,
         music_active,
@@ -160,13 +608,31 @@ pub fn draw_island(
     canvas.clear(Color::TRANSPARENT);
 
     let dock_bottom = dock_position.is_bottom();
-    let offset_x = if dock_position.is_left() {
+    let centered_offset_x = if dock_position.is_left() {
         PADDING / 2.0
     } else if dock_position.is_right() {
-        (os_w as f32 - PADDING / 2.0 - current_w).max(0.0)
+        (os_w as f32 - PADDING / 2.0 - target_w).max(0.0)
     } else {
-        (os_w as f32 - current_w) / 2.0
+        (os_w as f32 - target_w) / 2.0
     };
+    let group_shift = get_multitask_group_shift(MultitaskGroupLayoutParams {
+        base_h,
+        global_scale,
+        dock_position,
+        frame: multitask_frame,
+        hover_progress: multitask_hover_progress,
+    }) * compact_animation;
+    let promote_start_x = if dock_position.is_right() {
+        centered_offset_x - 7.0 * global_scale - compact_diameter
+    } else {
+        centered_offset_x + target_w + 7.0 * global_scale
+    };
+    let offset_x = if promote_progress < 1.0 {
+        promote_start_x + (centered_offset_x - promote_start_x) * promote_progress
+    } else {
+        centered_offset_x
+    } + group_shift
+        + multitask_frame.main_offset_units * global_scale * compact_animation;
     let base_y = if dock_bottom {
         os_h as f32 - PADDING / 2.0 - current_h
     } else {
@@ -353,7 +819,9 @@ pub fn draw_island(
     }
 
     let expanded_alpha_f = (expansion_progress.powf(2.0)).clamp(0.0, 1.0) * (1.0 - hide_progress);
-    let mini_alpha_f = (1.0 - expansion_progress * 1.5).clamp(0.0, 1.0) * (1.0 - hide_progress);
+    let mini_alpha_f = (1.0 - expansion_progress * 1.5).clamp(0.0, 1.0)
+        * (1.0 - hide_progress)
+        * multitask_frame.main_alpha;
 
     let palette = if expanded_alpha_f > 0.01 || mini_alpha_f > 0.01 {
         get_media_palette(media)
@@ -738,6 +1206,44 @@ pub fn draw_island(
         }
     }
     canvas.restore();
+
+    draw_multitask_bridge(
+        canvas,
+        MultitaskLayoutParams {
+            offset_x,
+            offset_y,
+            current_w,
+            current_h,
+            base_h,
+            global_scale,
+            dock_position,
+            frame: multitask_frame,
+            hover_progress: multitask_hover_progress,
+        },
+    );
+
+    draw_multitask_secondary(
+        canvas,
+        MultitaskSecondaryParams {
+            content: secondary_mini_content.as_ref(),
+            outgoing_content: outgoing_secondary_mini_content.as_ref(),
+            media,
+            offset_x,
+            offset_y,
+            current_w,
+            current_h,
+            base_h,
+            global_scale,
+            dock_position,
+            frame: MultitaskFrame {
+                secondary_alpha: multitask_frame.secondary_alpha * (1.0 - expansion_progress),
+                outgoing_secondary_alpha: multitask_frame.outgoing_secondary_alpha
+                    * (1.0 - expansion_progress),
+                ..multitask_frame
+            },
+            hover_progress: multitask_hover_progress,
+        },
+    );
 
     {
         let mut border_paint = Paint::default();

--- a/src/window/app.rs
+++ b/src/window/app.rs
@@ -1,8 +1,11 @@
 use crate::core::audio::AudioProcessor;
 use crate::core::config::{AppConfig, PADDING, TOP_OFFSET, WINDOW_TITLE};
-use crate::core::context::ContextManager;
+use crate::core::context::{ContextManager, MiniContent, Priority};
+use crate::core::multitask::{
+    MultitaskController, MultitaskTask, MultitaskTaskId, MultitaskTransitionKind,
+};
 use crate::core::persistence::load_config;
-use crate::core::render::draw_island;
+use crate::core::render::{draw_island, get_multitask_secondary_rect, MultitaskLayoutParams};
 use crate::core::smtc::SmtcListener;
 use crate::plugin::PluginManager;
 use crate::plugin::zip_loader;
@@ -102,6 +105,9 @@ pub struct App {
     is_right_dragging: bool,
     right_drag_start_pos: Option<(i32, i32)>,
     right_drag_start_offset: Option<(i32, i32)>,
+    multitask: MultitaskController,
+    spring_multitask_hover: Spring,
+    music_task_started_at: Option<Instant>,
 }
 
 impl Default for App {
@@ -170,6 +176,9 @@ impl Default for App {
             is_right_dragging: false,
             right_drag_start_pos: None,
             right_drag_start_offset: None,
+            multitask: MultitaskController::default(),
+            spring_multitask_hover: Spring::new(0.0),
+            music_task_started_at: None,
         }
     }
 }
@@ -460,11 +469,56 @@ impl App {
         }
     }
 
+    fn multitask_secondary_rect(&self, layout: &IslandLayout) -> Option<(f32, f32, f32, f32)> {
+        let now = Instant::now();
+        let frame = self.multitask.frame(now);
+        if self.multitask.secondary().is_none()
+            && self.multitask.outgoing_secondary().is_none()
+            && frame.secondary_alpha <= 0.01
+        {
+            return None;
+        }
+        Some(get_multitask_secondary_rect(MultitaskLayoutParams {
+            offset_x: layout.offset_x as f32,
+            offset_y: layout.current_island_y as f32,
+            current_w: self.spring_w.value,
+            current_h: self.spring_h.value,
+            base_h: self.config.base_height * self.config.global_scale,
+            global_scale: self.config.global_scale,
+            dock_position: self.config.dock_position,
+            frame,
+            hover_progress: self.spring_multitask_hover.value,
+        }))
+    }
+
+    fn multitask_secondary_hit(&self, rel_x: i32, rel_y: i32, layout: &IslandLayout) -> bool {
+        let Some((x, y, w, h)) = self.multitask_secondary_rect(layout) else {
+            return false;
+        };
+        if self.multitask.transition_kind() != MultitaskTransitionKind::Stable
+            || self.multitask.secondary().is_none()
+        {
+            return false;
+        }
+        let center_x = x + w / 2.0;
+        let center_y = y + h / 2.0;
+        let radius = w.min(h) / 2.0 + 3.0 * self.config.global_scale;
+        let dx = rel_x as f32 - center_x;
+        let dy = rel_y as f32 - center_y;
+        dx * dx + dy * dy <= radius * radius
+    }
+
     fn handle_press(&mut self, rel_x: i32, rel_y: i32, layout: &IslandLayout) {
         let island_y = layout.island_y;
         let offset_x = layout.offset_x;
         let current_island_y = layout.current_island_y;
-
+        if !self.expanded && self.multitask_secondary_hit(rel_x, rel_y, layout) {
+            if self.multitask.swap(Instant::now()) {
+                self.spring_multitask_hover.velocity = 0.12;
+                self.idle_timer = Instant::now();
+            }
+            return;
+        }
         let is_hovering_visible = is_point_in_rect(
             rel_x as f64,
             rel_y as f64,
@@ -1166,7 +1220,56 @@ impl ApplicationHandler for App {
                         self.ctx_mgr.set_smtc_active(music_active);
                         crate::plugin::manager::drain_pending_contexts(&mut self.ctx_mgr);
                         self.ctx_mgr.tick();
-                        let mini_content = self.ctx_mgr.current_mini();
+                        if music_active {
+                            self.music_task_started_at.get_or_insert(Instant::now());
+                        } else {
+                            self.music_task_started_at = None;
+                        }
+                        let mut candidates: Vec<_> = self
+                            .ctx_mgr
+                            .mini_candidates()
+                            .into_iter()
+                            .map(|context| MultitaskTask {
+                                id: MultitaskTaskId::Plugin(context.id.clone()),
+                                priority: context.priority,
+                                created_at: context.created_at,
+                                content: MiniContent::Plugin(Box::new(context)),
+                            })
+                            .collect();
+                        if let Some(created_at) = self.music_task_started_at {
+                            candidates.push(MultitaskTask {
+                                id: MultitaskTaskId::Music,
+                                content: MiniContent::Music,
+                                priority: Priority::Low,
+                                created_at,
+                            });
+                        }
+                        candidates.sort_by(|left, right| {
+                            right
+                                .priority
+                                .cmp(&left.priority)
+                                .then_with(|| right.created_at.cmp(&left.created_at))
+                        });
+                        if self.multitask.primary().is_none()
+                            && let Some(music_index) =
+                                candidates.iter().position(|task| task.id == MultitaskTaskId::Music)
+                        {
+                            let music = candidates.remove(music_index);
+                            candidates.insert(0, music);
+                        }
+                        self.multitask.reconcile(&candidates, Instant::now());
+
+                        let (mini_content, secondary_mini_content, outgoing_secondary_mini_content) = {
+                            let (primary, secondary) = self.multitask.display_tasks(Instant::now());
+                            (
+                                primary.map(|task| task.content),
+                                secondary.map(|task| task.content),
+                                self.multitask
+                                    .outgoing_secondary()
+                                    .map(|task| task.content.clone()),
+                            )
+                        };
+                        let multitask_frame = self.multitask.frame(Instant::now());
 
                         let widget_animating = draw_island(
                             surface,
@@ -1215,6 +1318,10 @@ impl ApplicationHandler for App {
                                     dt,
                                 },
                                 mini_content,
+                                secondary_mini_content,
+                                outgoing_secondary_mini_content,
+                                multitask_frame,
+                                multitask_hover_progress: self.spring_multitask_hover.value,
                             },
                         );
                         if widget_animating && let Some(win) = &self.window {
@@ -1592,6 +1699,17 @@ impl ApplicationHandler for App {
         self.spring_h.update_dt(target_h, 0.10, 0.68, dt);
         self.spring_r.update_dt(target_r, 0.10, 0.68, dt);
         self.spring_view.update_dt(target_view, 0.12, 0.68, dt);
+
+        let layout = self.compute_island_layout();
+        let multitask_hover_target = if !self.expanded
+            && self.multitask_secondary_hit(rel_x, rel_y, &layout)
+        {
+            1.0
+        } else {
+            0.0
+        };
+        self.spring_multitask_hover
+            .update_dt(multitask_hover_target, 0.16, 0.66, dt);
 
         let is_glass_or_mica = self.config.island_style == "glass"
             || self.config.island_style == "dynamic"


### PR DESCRIPTION
## Summary

Ports the **dual-task / multitask mode** into the island as a self-contained feature, without pulling in the agent or liquid-glass work it was previously entangled with.

The island can now show a **primary pill** plus a **secondary circular pill** beside it. Tasks are ordered by priority (then recency), and the two slots animate between states:

- **Split / Merge** — secondary pill grows out of / collapses back into the main island
- **Promote** — secondary promoted to primary when the main task ends
- **Replace** — a higher/newer third task takes the secondary slot
- **Swap** — click the secondary pill to swap primary/secondary

A "bridge" connector is drawn between the island and the secondary pill, and all transitions are driven by `MultitaskFrame` scaling/alpha parameters with keyframes.

## Changes

| File | Purpose |
|------|---------|
| `src/core/multitask.rs` | `MultitaskController`, `MultitaskFrame`, `MultitaskTask`, transition logic + unit tests |
| `src/core/context/mod.rs` | `mini_candidates()` for priority/ordered task selection |
| `src/core/render.rs` | secondary pill rendering, bridge connector, layout helpers |
| `src/core/mod.rs` | module wiring |
| `src/window/app.rs` | input handling, hover spring, animation integration |

## Notes

- Secondary pill uses a **solid background** (`Color::from_argb(alpha,7,7,9)`); liquid-glass rendering is intentionally excluded to keep this PR dual-task-only.
- `cargo clippy --all-targets` is clean and all 9 `multitask` unit tests pass.

## Test plan

- [ ] Build with `cargo build`
- [ ] Trigger two concurrent mini contexts and confirm split/merge animation
- [ ] Click the secondary pill to verify swap
- [ ] Let the primary task end and confirm promote-to-secondary

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy)