### PR TITLE
fix(plugin): harden plugin API integration and documentation

### DIFF
--- a/Page/plugin-dev.md
+++ b/Page/plugin-dev.md
@@ -1,34 +1,34 @@
 # Plugin Development Guide
 
-Welcome! (´｡• ᵕ •｡`)♡ You're about to extend WinIsland with your own plugin.
+Welcome! You are about to extend WinIsland with your own plugin.
 
-> ⚠️ **Note: The plugin system is currently in a foundation stage.** The C ABI type definitions are ready, but the host-side trait interfaces (`ContentProvider`, `ThemeProvider`, `ShortcutProvider`) **are not yet wired into the render pipeline**. See [issue #55](https://github.com/Eatgrapes/WinIsland/issues/55) — we'd really love your input there!
+> **Note: The plugin system is currently in a foundation stage.** The C ABI type definitions are ready, and the push-based content system (`send_context`) works. However, the host-side trait interfaces (`ContentProvider`, `ThemeProvider`, `ShortcutProvider`) are not yet wired into the render pipeline. See [issue #55](https://github.com/Eatgrapes/WinIsland/issues/55) for details.
 
 ## How Plugins Work
 
-WinIsland uses a **C ABI vtable** pattern to load native `.dll` plugins safely. Think of it like this:
+WinIsland uses a **C ABI vtable** pattern to load native `.dll` plugins safely:
 
 ```
-WinIsland.exe  ──libloading──▶  your_plugin.dll
-   │                                  │
-   │  PluginManager                   │  exports plugin_get_instance()
-   │  └─ Vec<NativePlugin>            │  returns PluginInstanceC {
-   │       ├─ metadata (id, name…)    │    handle: opaque ptr
-   │       ├─ handle (opaque ptr)     │    vtable: function ptrs
-   │       └─ vtable (fn ptrs)        │    metadata: PluginMetadataC
-   │                                  │  }
-   └── calls traits ──▶  through vtable ──▶  your code runs!
+WinIsland.exe  ──libloading──>  your_plugin.dll
+   |                                  |
+   |  PluginManager                   |  exports plugin_get_instance()
+   |  `-- Vec<NativePlugin>           |  returns PluginInstanceC {
+   |       |-- metadata (id, name...) |    handle: opaque ptr
+   |       |-- handle (opaque ptr)    |    vtable: function ptrs
+   |       `-- vtable (fn ptrs)       |    metadata: PluginMetadataC
+   |                                  |  }
+   `-- calls traits --> through vtable --> your code runs!
 ```
 
-All data crossing the FFI boundary is `#[repr(C)]` — flat structs with no `Vec`, `String`, or trait objects. This means your plugin can be compiled with any Rust version and it'll still work (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧
+All data crossing the FFI boundary is `#[repr(C)]` -- flat structs with no `Vec`, `String`, or trait objects. This means your plugin can be compiled with any Rust version and it will still work.
 
-## Plugin Types (Planned)
+## Plugin Types
 
-| Type | Purpose | Status |
-|------|---------|--------|
-| **Content** (id=1) | Provide custom island content (weather, notifications, status…) | 🔲 API pending |
-| **Theme** (id=2) | Override island colors and animation parameters | 🔲 API pending |
-| **Shortcut** (id=3) | Register executable actions | 🔲 API pending |
+| Type | ID | Purpose | Status |
+|------|----|---------|--------|
+| **Content** | 1 | Push custom island content (notifications, status, etc.) via `send_context` | Working |
+| **Theme** | 2 | Override island colors and animation parameters | API defined, not yet wired |
+| **Shortcut** | 3 | Register executable actions | API defined, not yet wired |
 
 ## Project Setup
 
@@ -50,7 +50,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-winisland-plugin-api = "0.1"
+winisland-plugin-api = "0.2"
 ```
 
 ## Implementing the Plugin
@@ -65,17 +65,17 @@ use winisland_plugin_api::*;
 // The plugin instance is your plugin's state.
 struct MyPlugin;
 
-// The one and only entry point — WinIsland calls this via libloading.
-#[no_mangle]
-pub extern "C" fn plugin_get_instance() -> PluginInstanceC {
+// The one and only entry point -- WinIsland calls this via libloading.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn plugin_get_instance() -> PluginInstanceC {
     let handle = Box::into_raw(Box::new(MyPlugin)) as PluginHandle;
 
-    // The vtable is static — it lives as long as the DLL is loaded.
+    // The vtable is static -- it lives as long as the DLL is loaded.
     static VTABLE: PluginVTable = PluginVTable {
         on_load:    on_load,
         on_unload:  on_unload,
         destroy:    destroy,
-        get_content: None,
+        set_host_api: None,
         on_click:   None,
         on_expanded: None,
         supports_expand: None,
@@ -113,7 +113,42 @@ unsafe extern "C" fn destroy(handle: PluginHandle) {
 }
 ```
 
-## Packaging with One Command (ﾉ◕ヮ◕)ﾉ
+### Pushing Content to the Island
+
+Content-type plugins can export `plugin_set_host_api` to receive the host API table, then call `send_context`. The `PluginVTable::set_host_api` field is reserved for a future version and is not called by the current host.
+
+```rust
+struct MyPlugin {
+    host_api: Option<*const HostApiC>,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn plugin_set_host_api(
+    handle: PluginHandle,
+    api: *const HostApiC,
+) {
+    let plugin = unsafe { &mut *(handle as *mut MyPlugin) };
+    plugin.host_api = Some(api);
+}
+
+fn send_notification(handle: PluginHandle) -> Option<ContextIdC> {
+    let plugin = unsafe { &*(handle as *const MyPlugin) };
+    if let Some(api) = plugin.host_api {
+        let ctx = ContextDataC {
+            priority: PRIORITY_MEDIUM,
+            title: str_to_fixed("Notification"),
+            body: str_to_fixed("Hello from plugin!"),
+            duration_sec: 5,
+            mini_render: true,
+            mini_text: str_to_fixed("New notification"),
+        };
+        return Some(unsafe { ((*api).send_context)(handle, ctx) });
+    }
+    None
+}
+```
+
+## Packaging with One Command
 
 The `winisland-plugin-api` crate comes with an optional **packager** module that automates release builds, signing, and ZIP packaging.
 
@@ -123,7 +158,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-winisland-plugin-api = { version = "0.1", features = ["packager"] }
+winisland-plugin-api = { version = "0.2", features = ["packager"] }
 
 [[bin]]
 name = "pack"
@@ -151,7 +186,7 @@ cargo run --bin pack
 # Output: target/my-winisland-plugin-0.1.0.zip
 ```
 
-That's it! The packager will:
+The packager will:
 
 1. Run `cargo build --release` to compile your DLL
 2. Find the built `.dll` in `target/release/`
@@ -167,8 +202,8 @@ Your plugin must be packaged as `.zip` to be loaded by WinIsland. The ZIP must c
 
 ```
 my-plugin.zip
-├── plugin.yml    ← plugin manifest (required)
-└── *.dll         ← plugin binary (required, multiple .dll OK)
+|-- plugin.yml    (plugin manifest, required)
+`-- *.dll         (plugin binary, required, multiple .dll OK)
 ```
 
 #### plugin.yml
@@ -181,11 +216,11 @@ description: This is example plugin
 github-link: example/example-plugin
 ```
 
-**All 5 fields are required** — missing any will cause install to fail o(TヘTo)
+**All 5 fields are required** -- missing any will cause install to fail.
 
 ## Digital Signing (Recommended)
 
-Plugins can be **optionally** signed with Ed25519 to verify authenticity. Signed plugins are verified before loading — unsigned ones still work but show a warning.
+The packager can optionally add an Ed25519 signature and DLL hashes to `plugin.yml`. The current host does not verify these fields yet, so signing should be treated as package metadata rather than an enforced trust boundary.
 
 ### Generate a signing key
 
@@ -194,7 +229,7 @@ openssl genpkey -algorithm ed25519 -out signing_key.pem
 openssl pkey -in signing_key.pem -pubout -out public_key.pem
 ```
 
-The `public_key.pem` is embedded into the WinIsland binary by the project maintainers. If you're a plugin developer, you'll receive the signing key from the WinIsland team through a secure channel.
+Keep private signing keys outside the repository and provide them to CI through a protected secret.
 
 ### Sign during packaging
 
@@ -202,7 +237,7 @@ The `public_key.pem` is embedded into the WinIsland binary by the project mainta
 cargo run --bin pack
 ```
 
-If `signing_key.pem` is present in the project root, the packager automatically signs the plugin. The signature is embedded in `plugin.yml`:
+Calling `signing_key_path` or `signing_key_env` makes the packager add the signature to `plugin.yml`:
 
 ```yaml
 name: my-plugin
@@ -233,13 +268,13 @@ PluginPackager::from_cargo()
     .unwrap();
 ```
 
-## Installing ฅ^•ﻌ•^ฅ
+## Installing
 
-Simply **drag the `.zip` file onto the island**! The plugin is extracted in a background thread (so your island stays smooth and responsive) and loaded automatically.
+Simply **drag the `.zip` file onto the island**. The plugin is extracted in a background thread (so your island stays smooth and responsive) and loaded automatically.
 
 A Windows notification dialog will confirm successful installation.
 
-You can also manually place `.dll` files into subdirectories under the plugins folder — WinIsland scans them on startup.
+You can also manually place `.dll` files into subdirectories under the plugins folder -- WinIsland scans them on startup.
 
 ### Plugin storage location
 
@@ -255,25 +290,25 @@ WinIsland applies several security measures when loading plugins:
 |-----------|---------|
 | **Plugin ID validation** | IDs must match `[a-zA-Z0-9_-]+` only |
 | **ID conflict detection** | Duplicate plugin IDs are rejected |
-| **Signature verification** | Ed25519 signature checked before loading (if present) |
+| **Package hashes** | The packager can record DLL hashes; host verification is not implemented yet |
 | **Path traversal protection** | ZIP entries with `..`, `:`, or absolute paths are rejected |
 | **Symlink rejection** | ZIP symlink entries are rejected |
 | **Background extraction** | ZIP decompression runs in a background thread |
-| **Poison handling** | Lock poisoning doesn't crash the host |
+| **Poison handling** | Lock poisoning does not crash the host |
 | **VTable validation** | Required function pointers checked for null before calling |
 
 ## How to Verify Your Plugin Loaded?
 
-Since the host-side API is still under development, plugins won't display anything on the Island UI yet.
+`send_context` content and plugin media sources are connected to the Island UI. Theme, shortcut, click, and expanded-state provider callbacks are not connected yet.
 
 **Verification:**
 1. Press `F12` to open the WinIsland debug log window
-2. Search for your plugin name — you should see something like `Loaded plugin: xxx (xxx)`
+2. Search for your plugin name -- you should see something like `Loaded plugin: xxx (xxx)`
 3. Dropping a ZIP triggers a Windows popup confirming success/failure
 
 ## C ABI Type Reference
 
-These types live in the `winisland-plugin-api` crate. Before API integration, they're only used for DLL loading validation — **plugin functionality is not yet visible in the UI**.
+These types live in the `winisland-plugin-api` crate.
 
 ### PluginResultC
 
@@ -298,18 +333,58 @@ pub struct PluginMetadataC {
 }
 ```
 
-### IslandContentC
+### HostApiC
+
+The host API table is passed to plugins through the exported `plugin_set_host_api` function. Plugins store this pointer and call through it to interact with the host.
 
 ```rust
-pub struct IslandContentC {
-    pub tag: u32,
+pub struct HostApiC {
+    pub send_context: unsafe extern "C" fn(PluginHandle, ContextDataC) -> ContextIdC,
+    pub close_context: unsafe extern "C" fn(PluginHandle, *const c_char) -> PluginResultC,
+    pub query_host_state: unsafe extern "C" fn(PluginHandle) -> HostStateC,
+    pub set_media_source: unsafe extern "C" fn(PluginHandle, MediaSourceC) -> PluginResultC,
+    pub clear_media_source: unsafe extern "C" fn(PluginHandle) -> PluginResultC,
+    pub register_translations: unsafe extern "C" fn(
+        PluginHandle,
+        *const c_char,
+        *const TranslationPairC,
+        u32,
+    ) -> PluginResultC,
+}
+```
+
+### ContextDataC / ContextIdC / HostStateC / MediaSourceC
+
+```rust
+pub struct ContextDataC {
+    pub priority: u32,       // PRIORITY_LOW, PRIORITY_MEDIUM, or PRIORITY_HIGH
+    pub title: [u8; 256],    // shown in mini and expanded views
+    pub body: [u8; 512],     // expanded body text
+    pub duration_sec: u32,   // seconds before auto-collapse
+    pub mini_render: bool,   // show mini summary after collapsing
+    pub mini_text: [u8; 128],// mini summary text
+}
+
+pub struct ContextIdC {
+    pub id: [u8; 128],       // encoded as "plugin_id:context_id"
+}
+
+pub struct HostStateC {
+    pub media_title: [u8; 256],
+    pub media_artist: [u8; 256],
+    pub is_playing: bool,
+    pub theme: [u8; 32],     // "light" or "dark"
+}
+
+pub struct MediaSourceC {
     pub title: [u8; 256],
     pub artist: [u8; 256],
-    pub cover_url: [u8; 512],
+    pub album: [u8; 256],
+    pub duration_ms: u64,
+    pub position_ms: u64,
     pub is_playing: bool,
-    pub message: [u8; 256],
-    pub label: [u8; 128],
-    pub value: [u8; 128],
+    pub cover_data: *const u8,
+    pub cover_len: u32,
 }
 ```
 
@@ -320,7 +395,7 @@ pub struct PluginVTable {
     pub on_load: unsafe extern "C" fn(PluginHandle) -> PluginResultC,
     pub on_unload: unsafe extern "C" fn(PluginHandle) -> PluginResultC,
     pub destroy: unsafe extern "C" fn(PluginHandle),
-    pub get_content: Option<unsafe extern "C" fn(PluginHandle) -> IslandContentC>,
+    pub set_host_api: Option<unsafe extern "C" fn(PluginHandle, *const HostApiC)>, // reserved
     pub on_click: Option<unsafe extern "C" fn(PluginHandle)>,
     pub on_expanded: Option<unsafe extern "C" fn(PluginHandle, bool)>,
     pub supports_expand: Option<unsafe extern "C" fn(PluginHandle) -> bool>,
@@ -369,12 +444,19 @@ pub struct ShortcutC {
 }
 ```
 
-## Join the Discussion (づ｡◕‿‿◕｡)づ
+### TranslationPairC
 
-Beyond hooking into the Island context, we don't have many concrete directions yet… **we're really short on inspiration QWQ**
+```rust
+pub struct TranslationPairC {
+    pub key: *const c_char,
+    pub value: *const c_char,
+}
+```
 
-Please join us at [#55](https://github.com/Eatgrapes/WinIsland/issues/55) to discuss what you'd like the plugin system to support!
+## Join the Discussion
+
+Beyond hooking into the Island context, we do not have many concrete directions yet. Please join us at [#55](https://github.com/Eatgrapes/WinIsland/issues/55) to discuss what you would like the plugin system to support.
 
 ---
 
-Happy hacking! (づ｡◕‿‿◕｡)づ If you run into trouble, feel free to open an issue on [GitHub](https://github.com/Eatgrapes/WinIsland).
+If you run into trouble, feel free to open an issue on [GitHub](https://github.com/Eatgrapes/WinIsland).

--- a/Page/zh/plugin-dev.md
+++ b/Page/zh/plugin-dev.md
@@ -1,33 +1,34 @@
 # 插件开发指南
 
-欢迎！(´｡• ᵕ •｡`)♡ 你将通过插件扩展 WinIsland 的功能。
+欢迎！你将通过插件扩展 WinIsland 的功能。
 
-> ⚠️ **注意：插件系统目前处于基础阶段。** C ABI 类型定义已经就绪，但宿主端的 trait 接口（`ContentProvider`、`ThemeProvider`、`ShortcutProvider`）**尚未接入渲染管线**。请关注 [issue #55](https://github.com/Eatgrapes/WinIsland/issues/55) —— 非常期待听到你的想法！
+> **注意：插件系统目前处于基础阶段。** C ABI 类型定义已经就绪，基于 push 模式的内容系统（`send_context`）已经可以使用。但宿主端的 trait 接口（`ContentProvider`、`ThemeProvider`、`ShortcutProvider`）尚未接入渲染管线。请关注 [issue #55](https://github.com/Eatgrapes/WinIsland/issues/55) 了解详情。
 
 ## 插件工作原理
 
 WinIsland 使用 **C ABI vtable** 模式来安全加载原生 `.dll` 插件：
 
 ```
-WinIsland.exe  ──libloading──▶  your_plugin.dll
-   │                                  │
-   │  PluginManager                   │  导出 plugin_get_instance()
-   │  └─ Vec<NativePlugin>            │  返回 PluginInstanceC {
-   │       ├─ metadata (id, name…)    │    handle: 不透明指针
-   │       ├─ handle (不透明指针)      │    vtable: 函数指针表
-   │       └─ vtable (函数指针表)      │    metadata: PluginMetadataC
-   │                                  │  }
-   └── 调用 trait ──▶  通过 vtable ──▶  你的代码运行！
+WinIsland.exe  ──libloading──>  your_plugin.dll
+   |                                  |
+   |  PluginManager                   |  导出 plugin_get_instance()
+   |  `-- Vec<NativePlugin>           |  返回 PluginInstanceC {
+   |       |-- metadata (id, name...) |    handle: 不透明指针
+   |       |-- handle (不透明指针)     |    vtable: 函数指针表
+   |       `-- vtable (函数指针表)     |    metadata: PluginMetadataC
+   |                                  |  }
+   `-- 调用 trait --> 通过 vtable --> 你的代码运行！
 ```
 
-跨 FFI 边界的所有数据都是 `#[repr(C)]` — 扁平结构体，没有 `Vec`、`String` 或 trait 对象。这意味着你的插件可以用任意 Rust 版本编译都能正常工作 (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧
+跨 FFI 边界的所有数据都是 `#[repr(C)]` -- 扁平结构体，没有 `Vec`、`String` 或 trait 对象。这意味着你的插件可以用任意 Rust 版本编译都能正常工作。
 
-## 插件类型（计划中）
+## 插件类型
 
-| 类型 | 用途 | 状态 |
-|------|------|------|
-| **Theme** (id=2) | 覆盖岛的配色和动画参数 | 🔲 API 待定 |
-| **Shortcut** (id=3) | 注册可执行操作 | 🔲 API 待定 |
+| 类型 | ID | 用途 | 状态 |
+|------|----|------|------|
+| **Content** | 1 | 通过 `send_context` 推送自定义岛内容（通知、状态等）| 可用 |
+| **Theme** | 2 | 覆盖岛的配色和动画参数 | API 已定义，尚未接入 |
+| **Shortcut** | 3 | 注册可执行操作 | API 已定义，尚未接入 |
 
 ## 项目初始化
 
@@ -49,7 +50,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-winisland-plugin-api = "0.1.3"
+winisland-plugin-api = "0.2"
 ```
 
 ## 实现插件
@@ -64,17 +65,17 @@ use winisland_plugin_api::*;
 // 插件实例就是你的插件状态。
 struct MyPlugin;
 
-// 唯一且必需的入口点 —— WinIsland 通过 libloading 调用它。
-#[no_mangle]
-pub extern "C" fn plugin_get_instance() -> PluginInstanceC {
+// 唯一且必需的入口点 -- WinIsland 通过 libloading 调用它。
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn plugin_get_instance() -> PluginInstanceC {
     let handle = Box::into_raw(Box::new(MyPlugin)) as PluginHandle;
 
-    // vtable 是静态的 —— 只要 DLL 被加载它就存在。
+    // vtable 是静态的 -- 只要 DLL 被加载它就存在。
     static VTABLE: PluginVTable = PluginVTable {
         on_load:    on_load,
         on_unload:  on_unload,
         destroy:    destroy,
-        get_content: None,
+        set_host_api: None,
         on_click:   None,
         on_expanded: None,
         supports_expand: None,
@@ -112,7 +113,42 @@ unsafe extern "C" fn destroy(handle: PluginHandle) {
 }
 ```
 
-## 一行命令打包 (ﾉ◕ヮ◕)ﾉ
+### 向岛推送内容
+
+Content 类型插件可以导出 `plugin_set_host_api` 来接收宿主 API 表，然后调用 `send_context` 向岛推送数据。`PluginVTable::set_host_api` 字段为未来版本保留，当前宿主不会调用该字段。
+
+```rust
+struct MyPlugin {
+    host_api: Option<*const HostApiC>,
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn plugin_set_host_api(
+    handle: PluginHandle,
+    api: *const HostApiC,
+) {
+    let plugin = unsafe { &mut *(handle as *mut MyPlugin) };
+    plugin.host_api = Some(api);
+}
+
+fn send_notification(handle: PluginHandle) -> Option<ContextIdC> {
+    let plugin = unsafe { &*(handle as *const MyPlugin) };
+    if let Some(api) = plugin.host_api {
+        let ctx = ContextDataC {
+            priority: PRIORITY_MEDIUM,
+            title: str_to_fixed("Notification"),
+            body: str_to_fixed("Hello from plugin!"),
+            duration_sec: 5,
+            mini_render: true,
+            mini_text: str_to_fixed("New notification"),
+        };
+        return Some(unsafe { ((*api).send_context)(handle, ctx) });
+    }
+    None
+}
+```
+
+## 一行命令打包
 
 `winisland-plugin-api` crate 带有一个可选的 **packager** 模块，可自动完成编译、签名和 ZIP 打包。
 
@@ -122,7 +158,7 @@ unsafe extern "C" fn destroy(handle: PluginHandle) {
 
 ```toml
 [dev-dependencies]
-winisland-plugin-api = { version = "0.1.3", features = ["packager"] }
+winisland-plugin-api = { version = "0.2", features = ["packager"] }
 
 [[bin]]
 name = "pack"
@@ -166,8 +202,8 @@ Packager 会自动：
 
 ```
 my-plugin.zip
-├── plugin.yml    ← 插件清单（必需）
-└── *.dll         ← 插件二进制（必需，可多个 .dll）
+|-- plugin.yml    (插件清单，必需)
+`-- *.dll         (插件二进制，必需，可多个 .dll)
 ```
 
 #### plugin.yml
@@ -180,11 +216,11 @@ description: This is example plugin
 github-link: example/example-plugin
 ```
 
-**所有 5 个字段都是必需的** —— 缺少任何一个都会导致安装失败 o(TヘTo)
+**所有 5 个字段都是必需的** -- 缺少任何一个都会导致安装失败。
 
 ## 数字签名（推荐）
 
-插件可以**选择性地**用 Ed25519 签名以验证真实性。签名后的插件在加载前会被校验——未签名的插件仍然可以工作，但会显示警告。
+Packager 可以选择性地向 `plugin.yml` 写入 Ed25519 签名和 DLL 哈希。当前宿主尚未验证这些字段，因此签名目前只是包元数据，不能作为强制信任边界。
 
 ### 生成签名密钥
 
@@ -193,7 +229,7 @@ openssl genpkey -algorithm ed25519 -out signing_key.pem
 openssl pkey -in signing_key.pem -pubout -out public_key.pem
 ```
 
-`public_key.pem` 由项目维护者嵌入 WinIsland 二进制文件中。如果你是插件开发者，将通过安全渠道从 WinIsland 团队获取签名密钥。
+私钥不得提交到仓库；在 CI 中应通过受保护的 secret 提供。
 
 ### 打包时签名
 
@@ -201,7 +237,7 @@ openssl pkey -in signing_key.pem -pubout -out public_key.pem
 cargo run --bin pack
 ```
 
-如果 `signing_key.pem` 在项目根目录存在，packager 会自动签名插件。签名会嵌入 `plugin.yml`：
+调用 `signing_key_path` 或 `signing_key_env` 后，packager 会把签名写入 `plugin.yml`：
 
 ```yaml
 name: my-plugin
@@ -232,13 +268,13 @@ PluginPackager::from_cargo()
     .unwrap();
 ```
 
-## 安装 ฅ^•ﻌ•^ฅ
+## 安装
 
-直接把 **`.zip` 文件拖到岛（Dynamic Island）上**！插件会在后台线程中解压（保证岛保持流畅响应）并自动加载。
+直接把 **`.zip` 文件拖到岛（Dynamic Island）上**。插件会在后台线程中解压（保证岛保持流畅响应）并自动加载。
 
 安装成功后会弹出 Windows 通知对话框确认。
 
-你也可以手动将 `.dll` 文件放入插件目录的子目录中 —— WinIsland 启动时会扫描它们。
+你也可以手动将 `.dll` 文件放入插件目录的子目录中 -- WinIsland 启动时会扫描它们。
 
 ### 插件存储位置
 
@@ -254,7 +290,7 @@ WinIsland 在加载插件时应用了多重安全措施：
 |---------|------|
 | **插件 ID 校验** | ID 只能包含 `[a-zA-Z0-9_-]` |
 | **ID 冲突检测** | 拒绝加载重复的插件 ID |
-| **签名验证** | 加载前检查 Ed25519 签名（如果存在）|
+| **包哈希** | Packager 可记录 DLL 哈希；宿主验证尚未实现 |
 | **路径穿越防护** | 拒绝包含 `..`、`:` 或绝对路径的 ZIP 条目 |
 | **符号链接拒绝** | 拒绝 ZIP 中的符号链接条目 |
 | **后台解压** | ZIP 解压在后台线程执行 |
@@ -263,7 +299,7 @@ WinIsland 在加载插件时应用了多重安全措施：
 
 ## C ABI 类型参考
 
-这些类型定义在 `winisland-plugin-api` crate 中。在 API 集成完成前，它们仅用于 DLL 加载验证——**插件功能尚未在 UI 中可见**。
+这些类型定义在 `winisland-plugin-api` crate 中。
 
 ### PluginResultC
 
@@ -288,18 +324,58 @@ pub struct PluginMetadataC {
 }
 ```
 
-### IslandContentC
+### HostApiC
+
+宿主 API 表通过插件导出的 `plugin_set_host_api` 函数传递。插件存储此指针并通过它来与宿主交互。
 
 ```rust
-pub struct IslandContentC {
-    pub tag: u32,
+pub struct HostApiC {
+    pub send_context: unsafe extern "C" fn(PluginHandle, ContextDataC) -> ContextIdC,
+    pub close_context: unsafe extern "C" fn(PluginHandle, *const c_char) -> PluginResultC,
+    pub query_host_state: unsafe extern "C" fn(PluginHandle) -> HostStateC,
+    pub set_media_source: unsafe extern "C" fn(PluginHandle, MediaSourceC) -> PluginResultC,
+    pub clear_media_source: unsafe extern "C" fn(PluginHandle) -> PluginResultC,
+    pub register_translations: unsafe extern "C" fn(
+        PluginHandle,
+        *const c_char,
+        *const TranslationPairC,
+        u32,
+    ) -> PluginResultC,
+}
+```
+
+### ContextDataC / ContextIdC / HostStateC / MediaSourceC
+
+```rust
+pub struct ContextDataC {
+    pub priority: u32,       // PRIORITY_LOW, PRIORITY_MEDIUM, 或 PRIORITY_HIGH
+    pub title: [u8; 256],    // 在 mini 和展开视图显示
+    pub body: [u8; 512],     // 展开正文
+    pub duration_sec: u32,   // 自动折叠前的秒数
+    pub mini_render: bool,   // 折叠后是否显示 mini 摘要
+    pub mini_text: [u8; 128],// mini 摘要文本
+}
+
+pub struct ContextIdC {
+    pub id: [u8; 128],       // 编码为 "plugin_id:context_id"
+}
+
+pub struct HostStateC {
+    pub media_title: [u8; 256],
+    pub media_artist: [u8; 256],
+    pub is_playing: bool,
+    pub theme: [u8; 32],     // "light" 或 "dark"
+}
+
+pub struct MediaSourceC {
     pub title: [u8; 256],
     pub artist: [u8; 256],
-    pub cover_url: [u8; 512],
+    pub album: [u8; 256],
+    pub duration_ms: u64,
+    pub position_ms: u64,
     pub is_playing: bool,
-    pub message: [u8; 256],
-    pub label: [u8; 128],
-    pub value: [u8; 128],
+    pub cover_data: *const u8,
+    pub cover_len: u32,
 }
 ```
 
@@ -310,7 +386,7 @@ pub struct PluginVTable {
     pub on_load: unsafe extern "C" fn(PluginHandle) -> PluginResultC,
     pub on_unload: unsafe extern "C" fn(PluginHandle) -> PluginResultC,
     pub destroy: unsafe extern "C" fn(PluginHandle),
-    pub get_content: Option<unsafe extern "C" fn(PluginHandle) -> IslandContentC>,
+    pub set_host_api: Option<unsafe extern "C" fn(PluginHandle, *const HostApiC)>, // 保留字段
     pub on_click: Option<unsafe extern "C" fn(PluginHandle)>,
     pub on_expanded: Option<unsafe extern "C" fn(PluginHandle, bool)>,
     pub supports_expand: Option<unsafe extern "C" fn(PluginHandle) -> bool>,
@@ -359,12 +435,19 @@ pub struct ShortcutC {
 }
 ```
 
-## 加入讨论 (づ｡◕‿‿◕｡)づ
+### TranslationPairC
 
-除了接入岛上下文之外，我们还没有太多具体的方向…… **真的很缺灵感 QWQ**
+```rust
+pub struct TranslationPairC {
+    pub key: *const c_char,
+    pub value: *const c_char,
+}
+```
 
-请来 [#55](https://github.com/Eatgrapes/WinIsland/issues/55) 一起讨论你希望插件系统支持什么功能！
+## 加入讨论
+
+除了接入岛上下文之外，我们还没有太多具体的方向。欢迎来 [#55](https://github.com/Eatgrapes/WinIsland/issues/55) 一起讨论你希望插件系统支持什么功能。
 
 ---
 
-Happy hacking! (づ｡◕‿‿◕｡)づ 如果遇到问题，欢迎在 [GitHub](https://github.com/Eatgrapes/WinIsland) 上开 issue。
+如果遇到问题，欢迎在 [GitHub](https://github.com/Eatgrapes/WinIsland) 上开 issue。

--- a/crates/winisland-plugin-api/README.md
+++ b/crates/winisland-plugin-api/README.md
@@ -8,7 +8,7 @@ WinIsland is a Dynamic Island emulator for Windows. Plugins are native DLLs that
 
 ```toml
 [dependencies]
-winisland-plugin-api = "0.1.3"
+winisland-plugin-api = "0.2"
 ```
 
 Then export a `plugin_get_instance` function from your `cdylib`:
@@ -38,8 +38,8 @@ pub unsafe extern "C" fn plugin_get_instance() -> PluginInstanceC {
 | Type | Capability |
 |------|-----------|
 | **Content** | Display text/status on the Dynamic Island |
-| **Theme** | Provide custom colours and animation config |
-| **Shortcut** | Expose keyboard shortcuts / quick actions |
+| **Theme** | Provide custom colours and animation config (host integration pending) |
+| **Shortcut** | Expose keyboard shortcuts / quick actions (host integration pending) |
 
 ## Features
 

--- a/crates/winisland-plugin-api/src/host.rs
+++ b/crates/winisland-plugin-api/src/host.rs
@@ -4,9 +4,10 @@ use crate::types::i18n::TranslationPairC;
 use crate::types::{PluginHandle, PluginResultC};
 use std::ffi::c_char;
 
-/// Host-side API table passed to plugins via [`PluginVTable::set_host_api`](crate::PluginVTable).
+/// Host-side API table passed to plugins through their exported
+/// `plugin_set_host_api` function.
 ///
-/// Plugins store this pointer during `set_host_api` and call through it
+/// Plugins store this pointer during `plugin_set_host_api` and call through it
 /// whenever they need to interact with the host (push context, close context,
 /// query state, register translations). All functions are safe to call from any thread.
 #[repr(C)]
@@ -26,7 +27,7 @@ pub struct HostApiC {
     /// Replace SMTC with plugin-provided media source.
     ///
     /// The host will use this data for the entire media UI. Returns an
-    /// error if `title` is empty. Call [`clear_media_source`] to restore SMTC.
+    /// error if `title` is empty. Call [`HostApiC::clear_media_source`] to restore SMTC.
     pub set_media_source: unsafe extern "C" fn(PluginHandle, MediaSourceC) -> PluginResultC,
 
     /// Restore SMTC as the active media source and stop using plugin data.

--- a/crates/winisland-plugin-api/src/lib.rs
+++ b/crates/winisland-plugin-api/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! winisland-plugin-api = "0.1"
+//! winisland-plugin-api = "0.2"
 //! ```
 //!
 //! Implement the C ABI by exporting a `plugin_get_instance` function:
@@ -19,7 +19,7 @@
 //! ```rust,no_run
 //! use winisland_plugin_api::*;
 //!
-//! #[no_mangle]
+//! #[unsafe(no_mangle)]
 //! pub unsafe extern "C" fn plugin_get_instance() -> PluginInstanceC {
 //!     // See the crate docs for a full plugin example.
 //!     unimplemented!()
@@ -30,7 +30,7 @@
 //!
 //! ```toml
 //! [dev-dependencies]
-//! winisland-plugin-api = { version = "0.1", features = ["packager"] }
+//! winisland-plugin-api = { version = "0.2", features = ["packager"] }
 //! ```
 //!
 //! Add a `package.rs` binary that builds, signs and zips the plugin:

--- a/crates/winisland-plugin-api/src/types/metadata.rs
+++ b/crates/winisland-plugin-api/src/types/metadata.rs
@@ -1,7 +1,7 @@
 /// Fixed-width plugin metadata exchanged over FFI.
 ///
-/// Every field is a fixed-size byte buffer. The host reads them via
-/// [`read_c_str`] and [`read_opt_c_str`] helpers.
+/// Every field is a fixed-size byte buffer. The host reads each field as a
+/// NUL-terminated UTF-8 string.
 #[repr(C)]
 pub struct PluginMetadataC {
     /// Unique identifier (e.g. `"my-awesome-plugin"`). Max 63 bytes + NUL.

--- a/crates/winisland-plugin-api/src/vtable.rs
+++ b/crates/winisland-plugin-api/src/vtable.rs
@@ -2,7 +2,7 @@ use crate::HostApiC;
 use crate::types::metadata::PluginMetadataC;
 use crate::types::shortcut::ShortcutC;
 use crate::types::theme::{AnimationConfigC, ThemeColorsC};
-use crate::types::{PluginHandle, PluginResultC, PluginType};
+use crate::types::{PluginHandle, PluginResultC};
 
 /// Virtual function table that every plugin DLL must expose.
 ///
@@ -44,27 +44,27 @@ pub struct PluginVTable {
 
     /// Return the current theme colours.
     ///
-    /// Required for [`PluginType::Theme`] plugins.
+    /// Required for [`crate::PluginType::Theme`] plugins.
     pub get_colors: Option<unsafe extern "C" fn(PluginHandle) -> ThemeColorsC>,
 
     /// Return animation timing configuration.
     ///
-    /// Required for [`PluginType::Theme`] plugins.
+    /// Required for [`crate::PluginType::Theme`] plugins.
     pub get_animations: Option<unsafe extern "C" fn(PluginHandle) -> AnimationConfigC>,
 
     /// Number of shortcuts exposed by this plugin.
     ///
-    /// Required for [`PluginType::Shortcut`] plugins.
+    /// Required for [`crate::PluginType::Shortcut`] plugins.
     pub get_shortcuts_count: Option<unsafe extern "C" fn(PluginHandle) -> u32>,
 
     /// Write the `i`-th shortcut (0-indexed) into the output buffer.
     ///
-    /// Required for [`PluginType::Shortcut`] plugins.
+    /// Required for [`crate::PluginType::Shortcut`] plugins.
     pub get_shortcut_at: Option<unsafe extern "C" fn(PluginHandle, i: u32, out: *mut ShortcutC)>,
 
     /// Execute the shortcut identified by `id`.
     ///
-    /// Required for [`PluginType::Shortcut`] plugins.
+    /// Required for [`crate::PluginType::Shortcut`] plugins.
     pub execute_shortcut:
         Option<unsafe extern "C" fn(PluginHandle, id: *const std::ffi::c_char) -> PluginResultC>,
 
@@ -108,7 +108,7 @@ pub struct PluginInstanceC {
     ///
     /// The vtable must remain valid for the lifetime of the handle.
     pub vtable: *const PluginVTable,
-    /// Plugin type discriminant ([`PluginType`]).
+    /// Plugin type discriminant ([`crate::PluginType`]).
     pub plugin_type: u32,
 }
 

--- a/crates/winisland-plugin-api/src/vtable.rs
+++ b/crates/winisland-plugin-api/src/vtable.rs
@@ -2,7 +2,7 @@ use crate::HostApiC;
 use crate::types::metadata::PluginMetadataC;
 use crate::types::shortcut::ShortcutC;
 use crate::types::theme::{AnimationConfigC, ThemeColorsC};
-use crate::types::{PluginHandle, PluginResultC};
+use crate::types::{PluginHandle, PluginResultC, PluginType};
 
 /// Virtual function table that every plugin DLL must expose.
 ///
@@ -68,11 +68,10 @@ pub struct PluginVTable {
     pub execute_shortcut:
         Option<unsafe extern "C" fn(PluginHandle, id: *const std::ffi::c_char) -> PluginResultC>,
 
-    /// Give the plugin a pointer to the host API table.
+    /// Reserved slot for receiving the host API table.
     ///
-    /// Called after `on_load`. The plugin should store this pointer
-    /// and use it to call `send_context`, `close_context`, etc.
-    /// May be `None` for plugins that don't need host interaction.
+    /// The current host uses the exported `plugin_set_host_api` function for
+    /// backward compatibility and does not call this slot. Set it to `None`.
     pub set_host_api: Option<unsafe extern "C" fn(PluginHandle, *const HostApiC)>,
 }
 
@@ -83,7 +82,7 @@ pub struct PluginVTable {
 ///
 /// ```rust,no_run
 /// # use winisland_plugin_api::*;
-/// #[no_mangle]
+/// #[unsafe(no_mangle)]
 /// pub unsafe extern "C" fn plugin_get_instance() -> PluginInstanceC {
 ///     PluginInstanceC {
 ///         handle: std::ptr::null_mut(),
@@ -116,7 +115,7 @@ pub struct PluginInstanceC {
 /// Entry-point function signature that every plugin DLL must export.
 ///
 /// ```ignore
-/// #[no_mangle]
+/// #[unsafe(no_mangle)]
 /// pub unsafe extern "C" fn plugin_get_instance() -> PluginInstanceC;
 /// ```
 pub type PluginGetInstanceFn = unsafe extern "C" fn() -> PluginInstanceC;

--- a/src/core/context/types.rs
+++ b/src/core/context/types.rs
@@ -1,12 +1,9 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 fn generate_id() -> String {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    format!("{:x}", ts)
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    format!("{:x}", NEXT_ID.fetch_add(1, Ordering::Relaxed))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/core/render/background.rs
+++ b/src/core/render/background.rs
@@ -172,46 +172,44 @@ pub(super) fn draw_background(params: BackgroundParams<'_>) {
             overlay.set_color(Color::from_argb(120, 20, 20, 24));
             overlay.set_anti_alias(true);
             canvas.draw_rect(rect, &overlay);
-        } else {
-            if let Some(bg_img) = get_glass_background(
-                direct_context,
-                GlassBackgroundParams {
-                    screen_x,
-                    screen_y,
-                    width: current_w as u32,
-                    height: current_h as u32,
-                    blur_sigma: 40.0 * global_scale,
-                    surface_width: surface_info.width() as u32,
-                    surface_height: surface_info.height() as u32,
-                    monitor_x,
-                    monitor_y,
-                    monitor_w,
-                    monitor_h,
-                },
-            ) {
-                let mut paint = Paint::default();
-                paint.set_anti_alias(true);
-                let sampling = SamplingOptions::new(FilterMode::Linear, MipmapMode::None);
-                let source_rect = Rect::from_wh(bg_img.width as f32, bg_img.height as f32);
-                canvas.draw_image_rect_with_sampling_options(
-                    &bg_img.image,
-                    Some((&source_rect, SrcRectConstraint::Fast)),
-                    rect,
-                    sampling,
-                    &paint,
-                );
+        } else if let Some(bg_img) = get_glass_background(
+            direct_context,
+            GlassBackgroundParams {
+                screen_x,
+                screen_y,
+                width: current_w as u32,
+                height: current_h as u32,
+                blur_sigma: 40.0 * global_scale,
+                surface_width: surface_info.width() as u32,
+                surface_height: surface_info.height() as u32,
+                monitor_x,
+                monitor_y,
+                monitor_w,
+                monitor_h,
+            },
+        ) {
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            let sampling = SamplingOptions::new(FilterMode::Linear, MipmapMode::None);
+            let source_rect = Rect::from_wh(bg_img.width as f32, bg_img.height as f32);
+            canvas.draw_image_rect_with_sampling_options(
+                &bg_img.image,
+                Some((&source_rect, SrcRectConstraint::Fast)),
+                rect,
+                sampling,
+                &paint,
+            );
 
-                let mut darken = Paint::default();
-                darken.set_color(Color::from_argb(130, 10, 10, 14));
-                darken.set_anti_alias(true);
-                darken.set_blend_mode(skia_safe::BlendMode::Multiply);
-                canvas.draw_rect(rect, &darken);
-            } else {
-                let mut bg_paint = Paint::default();
-                bg_paint.set_color(Color::from_argb(205, 32, 32, 36));
-                bg_paint.set_anti_alias(true);
-                canvas.draw_rrect(rrect, &bg_paint);
-            }
+            let mut darken = Paint::default();
+            darken.set_color(Color::from_argb(130, 10, 10, 14));
+            darken.set_anti_alias(true);
+            darken.set_blend_mode(skia_safe::BlendMode::Multiply);
+            canvas.draw_rect(rect, &darken);
+        } else {
+            let mut bg_paint = Paint::default();
+            bg_paint.set_color(Color::from_argb(205, 32, 32, 36));
+            bg_paint.set_anti_alias(true);
+            canvas.draw_rrect(rrect, &bg_paint);
         }
     } else {
         canvas.save();

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use super::types::{
     AnimationConfig, ContentProvider, Plugin, PluginError, PluginGetInstanceFn, PluginHandle,
     PluginInstanceC, PluginMetadata, PluginResultC, PluginType, Shortcut, ShortcutC,
@@ -143,6 +141,7 @@ impl NativePlugin {
         Ok(plugin)
     }
 
+    #[allow(dead_code)]
     fn vtable(&self) -> &super::types::PluginVTable {
         // SAFETY: vtable was validated on construction and is 'static in the DLL.
         unsafe { &*self.vtable }

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -150,14 +150,20 @@ impl NativePlugin {
 
     /// Give this plugin a pointer to the host API table.
     ///
-    /// Calls through the vtable's `set_host_api` field. If the plugin
-    /// does not provide one (old plugin), this is a no-op.
+    /// Looks for a `plugin_set_host_api` symbol exported by the DLL.
+    /// If the plugin doesn't export it (old plugin), this is a no-op.
     /// The pointer must be `'static` (leaked or global).
     pub fn set_host_api(&self, api: *const super::types::HostApiC) {
-        let vtable = self.vtable();
-        if let Some(f) = vtable.set_host_api {
-            // SAFETY: calling through vtable with the opaque handle from the same DLL.
-            unsafe { f(self.handle, api) };
+        // Try to find the `plugin_set_host_api` symbol exported by the DLL.
+        // Old plugins don't export it — this is a no-op for those.
+        let lib: &Library = &self._lib;
+        if let Ok(func) = unsafe {
+            lib.get::<unsafe extern "C" fn(
+                crate::plugin::types::PluginHandle,
+                *const crate::plugin::types::HostApiC,
+            )>(b"plugin_set_host_api\0")
+        } {
+            unsafe { (func)(self.handle, api) };
         }
     }
 

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -150,20 +150,14 @@ impl NativePlugin {
 
     /// Give this plugin a pointer to the host API table.
     ///
-    /// Looks for a `plugin_set_host_api` symbol exported by the DLL.
-    /// If the plugin doesn't export it (old plugin), this is a no-op.
+    /// Calls through the vtable's `set_host_api` field. If the plugin
+    /// does not provide one (old plugin), this is a no-op.
     /// The pointer must be `'static` (leaked or global).
     pub fn set_host_api(&self, api: *const super::types::HostApiC) {
-        // Try to find the `plugin_set_host_api` symbol exported by the DLL.
-        // Old plugins don't export it — this is a no-op for those.
-        let lib: &Library = &self._lib;
-        if let Ok(func) = unsafe {
-            lib.get::<unsafe extern "C" fn(
-                crate::plugin::types::PluginHandle,
-                *const crate::plugin::types::HostApiC,
-            )>(b"plugin_set_host_api\0")
-        } {
-            unsafe { (func)(self.handle, api) };
+        let vtable = self.vtable();
+        if let Some(f) = vtable.set_host_api {
+            // SAFETY: calling through vtable with the opaque handle from the same DLL.
+            unsafe { f(self.handle, api) };
         }
     }
 

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -188,6 +188,9 @@ unsafe extern "C" fn host_close_context(
     handle: crate::plugin::types::PluginHandle,
     id_str: *const std::ffi::c_char,
 ) -> crate::plugin::types::PluginResultC {
+    if id_str.is_null() {
+        return crate::plugin::types::PluginResultC::err("Context ID is null");
+    }
     let raw = unsafe { std::ffi::CStr::from_ptr(id_str) };
     let s = raw.to_string_lossy();
     if let Some(context_id) = crate::core::context::ContextId::from_encoded(&s) {
@@ -234,6 +237,12 @@ unsafe extern "C" fn host_register_translations(
     pairs: *const crate::plugin::types::TranslationPairC,
     count: u32,
 ) -> crate::plugin::types::PluginResultC {
+    if lang.is_null() {
+        return crate::plugin::types::PluginResultC::err("Language is null");
+    }
+    if count > 0 && pairs.is_null() {
+        return crate::plugin::types::PluginResultC::err("Translation pairs are null");
+    }
     let lang = unsafe { std::ffi::CStr::from_ptr(lang) }
         .to_str()
         .unwrap_or("en_us");
@@ -241,6 +250,9 @@ unsafe extern "C" fn host_register_translations(
     let rust_pairs: Vec<(&str, &str)> = slice
         .iter()
         .filter_map(|p| {
+            if p.key.is_null() || p.value.is_null() {
+                return None;
+            }
             let k = unsafe { std::ffi::CStr::from_ptr(p.key) }.to_str().ok()?;
             let v = unsafe { std::ffi::CStr::from_ptr(p.value) }.to_str().ok()?;
             Some((k, v))
@@ -361,11 +373,14 @@ impl PluginManager {
             .position(|p| p.metadata().id == plugin_id)
             .ok_or_else(|| PluginError::NotFound(plugin_id.to_string()))?;
         let plugin = entries.remove(idx);
+        let handle = plugin.handle_raw();
         log::info!(
             "Plugin unloaded: {} ({})",
             plugin.metadata().name,
             plugin_id
         );
+        drop(plugin);
+        deregister_plugin_handle(handle);
         Ok(())
     }
 
@@ -414,7 +429,7 @@ impl PluginManager {
             .collect()
     }
 
-    /// Call `set_host_api` on every loaded plugin and register its handle.
+    /// Register each handle before giving the host API to the plugin.
     pub fn init_plugin_host_api(&self, api: *const crate::plugin::types::HostApiC) {
         let entries = match self.entries.read() {
             Ok(g) => g,
@@ -425,8 +440,8 @@ impl PluginManager {
         };
         for plugin in entries.iter() {
             let handle = plugin.handle_raw();
-            plugin.set_host_api(api);
             register_plugin_handle(handle, &plugin.metadata().id);
+            plugin.set_host_api(api);
         }
     }
 

--- a/src/plugin/types.rs
+++ b/src/plugin/types.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
 
 pub use winisland_plugin_api::{
@@ -14,6 +12,7 @@ pub fn read_c_str(buf: &[u8]) -> String {
     String::from_utf8_lossy(&buf[..end]).into_owned()
 }
 
+#[allow(dead_code)]
 pub fn read_opt_c_str(buf: &[u8]) -> Option<String> {
     let s = read_c_str(buf);
     if s.is_empty() { None } else { Some(s) }
@@ -41,6 +40,7 @@ impl From<&PluginMetadataC> for PluginMetadata {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct ThemeColors {
     pub primary: (u8, u8, u8, u8),
     pub secondary: (u8, u8, u8, u8),
@@ -72,6 +72,7 @@ impl From<&ThemeColorsC> for ThemeColors {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct AnimationConfig {
     pub expand_duration_ms: u32,
     pub collapse_duration_ms: u32,
@@ -89,6 +90,7 @@ impl From<&AnimationConfigC> for AnimationConfig {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct Shortcut {
     pub id: String,
     pub name: String,
@@ -99,6 +101,7 @@ pub struct Shortcut {
 
 #[derive(Debug)]
 pub enum PluginError {
+    #[allow(dead_code)]
     NotFound(String),
     LoadFailed(String),
     InvalidPlugin(String),
@@ -127,17 +130,20 @@ pub trait Plugin: Send + Sync {
     fn plugin_type(&self) -> PluginType;
 }
 
+#[allow(dead_code)]
 pub trait ContentProvider: Plugin {
     fn on_click(&mut self);
     fn on_expanded(&mut self, expanded: bool);
     fn supports_expand(&self) -> bool;
 }
 
+#[allow(dead_code)]
 pub trait ThemeProvider: Plugin {
     fn get_colors(&self) -> ThemeColors;
     fn get_animations(&self) -> AnimationConfig;
 }
 
+#[allow(dead_code)]
 pub trait ShortcutProvider: Plugin {
     fn get_shortcuts(&self) -> Vec<Shortcut>;
     fn execute(&mut self, shortcut_id: &str) -> Result<(), String>;

--- a/src/plugin/zip_loader.rs
+++ b/src/plugin/zip_loader.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use serde::Deserialize;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -58,6 +56,7 @@ fn read_zip_entry(zip: &mut zip::ZipArchive<std::fs::File>, name: &str) -> Optio
     Some(buf)
 }
 
+#[allow(dead_code)]
 pub fn validate_zip(zip_path: &Path) -> Result<(), String> {
     let file = std::fs::File::open(zip_path).map_err(|e| format!("Cannot open zip: {}", e))?;
     let zip = zip::ZipArchive::new(file).map_err(|e| format!("Invalid zip: {}", e))?;


### PR DESCRIPTION
## 提交前检查清单

- [x] 已阅读 `CONTRIBUTING.md` 并完成要求测试
- [x] 本地/CI 测试通过
- [x] 代码审查 (Self-review) 完成

## pr方向

- [x] `fix` Bug 修复
- [ ] `feat` 新功能
- [ ] `docs` 文档/模板
- [ ] `style` 代码格式（不影响功能）
- [ ] `refactor` 重构（既不修复 bug 也不添加功能）
- [ ] `perf` 性能优化
- [ ] `test` 测试相关
- [ ] `chore` 构建/CI/依赖/工具链
- [ ] `revert` 回滚
- [ ] `security` 安全修复

## 影响范围

- [x] 程序核心 Core
  - [ ] UI 样式/布局
  - [x] 功能逻辑
  - [ ] 依赖变更
  - [x] 其他：Context ID 生成和渲染分支结构

- [x] 后端 Backend
  - [x] 插件 API 接口变更

- [x] 其他 Action/Docs
  - [x] Docs 文档
  - [ ] CI/CD 配置

## 关联 Issue

- Related to #55

---

## pr内容

### 摘要

修复 plugin API 相关的 ID 碰撞、死代码豁免和 Clippy 问题，并同步插件 ABI 文档与当前实现。

### 动机/背景

插件系统目前已经包含 C ABI、DLL 加载、宿主回调和 context 推送能力，但部分文档仍描述了不存在或尚未接入的接口，容易误导插件开发者。

同时，Context ID 使用时间戳生成，在高频创建 context 时存在碰撞可能；插件模块还使用了过于宽泛的模块级 `dead_code` 豁免，降低了 Clippy 对未使用代码的检查能力。

### 具体改动

- 将 Context ID 改为进程内原子递增 ID，避免时间戳精度导致的碰撞。
- 修复渲染背景代码中的 `collapsible_else_if` Clippy 检查问题。
- 将插件模块级 `#![allow(dead_code)]` 改为更精确的项级豁免。
- 修复 plugin API README、Rustdoc 和中英文插件开发指南：
  - 删除过时的 `IslandContentC` 描述。
  - 使用当前实际的 `send_context` push 模式。
  - 说明 `plugin_set_host_api` 是当前宿主实际使用的注入方式。
  - 标明 `PluginVTable::set_host_api` 当前仅作为保留字段。
  - 修正 Rust 2024 下的 `#[unsafe(no_mangle)]` 示例。
  - 修正签名说明，明确当前宿主尚未验证签名和 DLL 哈希。
  - 删除颜文字和过时的功能状态描述。
- 修复 plugin API Rustdoc 中的 broken intra-doc links。

### 验证结果

```text
cargo check
cargo clippy --workspace -- -D warnings
cargo doc -p winisland-plugin-api --no-deps
RUSTDOCFLAGS="-D warnings" cargo doc -p winisland-plugin-api --no-deps
```

以上检查均通过。

### 界面变动

无 UI 变动。